### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/tetzng/pez/security/code-scanning/1](https://github.com/tetzng/pez/security/code-scanning/1)

The best fix is to add a `permissions:` block at the root level of the workflow (`.github/workflows/ci.yaml`), just after the `name:` key and before the `on:` key. This applies `permissions` to all jobs unless locally overridden. The minimal required permission for this CI workflow, which simply checks out code and runs tests and linters, is `contents: read`. No job or step needs repository write access. Insert the following block:  
```yaml
permissions:
  contents: read
```  
No imports or additional steps are needed. Only edit the workflow YAML file to add the block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
