### PR TITLE
feat(install): bound clone concurrency by PEZ_JOBS (CLI targets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ and will append information if it already exists.
 
 ### Concurrency
 
-Control job parallelism for upgrade/uninstall/prune with `PEZ_JOBS` (default: 4).
+Control job parallelism with `PEZ_JOBS` (default: 4):
+- `install` (CLIで明示ターゲットを指定した場合) の clone は `PEZ_JOBS` で制限
+- `upgrade` / `uninstall` / `prune` も同様に `PEZ_JOBS` を使用
 
 ## Acknowledgements
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -20,7 +20,7 @@ Global options
   - `owner/repo` resolves to `https://github.com/owner/repo`; `host/...` without a scheme is normalized to `https://host/...`.
   - Selectors: `@latest`, `@version:<v>`, `@branch:<b>`, `@tag:<t>`, `@commit:<sha>` influence the resolved commit for fresh installs and `install --force`.
   - Duplicate files: pez maintains a set of destination paths encountered during the run and skips a plugin if copying would overwrite an existing file (applies to both CLI targets and `pez.toml`). A warning is printed and the plugin’s files are not recorded.
-  - Concurrency: with explicit targets, clones run concurrently and file copies run sequentially with duplicate‑path detection; installs from `pez.toml` are processed sequentially with the same duplicate detection.
+  - Concurrency: with explicit targets, clones run concurrently (bounded by `PEZ_JOBS`) and file copies run sequentially with duplicate‑path detection; installs from `pez.toml` are processed sequentially（同じ重複検出あり）。
 
 ## uninstall
 


### PR DESCRIPTION
- **test(git): hermetic test for get_latest_remote_commit using local bare remote and clone; ensures fetch/credentials flow works offline**
- **feat(install): bound clone concurrency by PEZ_JOBS using for_each_concurrent; keep file copy sequential with dedupe**
- **docs(concurrency): document PEZ_JOBS bound for install clones; clarify global concurrency behavior**
