### PR TITLE
ci(release): build/test on tag push and upload artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cargo fmt
+        run: cargo fmt --all -- --check
+      - name: Cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Cargo test
+        run: cargo test --all-features
+      - name: Build release binaries
+        run: |
+          cargo build --release
+          mkdir -p dist
+          cp target/release/pez dist/pez-$GITHUB_REF_NAME-linux-amd64
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pez-$GITHUB_REF_NAME
+          path: dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,12 @@
 name: release
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ and will append information if it already exists.
 ### Concurrency
 
 Control job parallelism with `PEZ_JOBS` (default: 4):
+
 - `install` (when CLI explicit targets are given): cloning is bounded by `PEZ_JOBS`
 - `upgrade` / `uninstall` / `prune` also honor `PEZ_JOBS`
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -20,6 +20,21 @@ From source (this repo):
 cargo install --path .
 ```
 
+From GitHub Releases (prebuilt binary, when available):
+
+```shell
+# Visit the Releases page and download the asset for your platform.
+# Example (Linux x86_64):
+curl -fsSL -o pez https://github.com/<owner>/<repo>/releases/download/<tag>/pez-<tag>-linux-amd64
+chmod +x pez
+./pez -V
+```
+
+Notes
+
+- On tagged releases (`v*.*.*`), CI builds, tests, and uploads release artifacts.
+- Asset filenames vary by platform; check the release page for the exact names.
+
 ### Build from source
 
 ```shell


### PR DESCRIPTION
- **refactor(core): remove unwrap/panic from production paths; handle HEAD fallback errors; propagate Arc unwrap error; harden uninstall/prune/upgrade file removals**
- **chore(repo): ignore repomix-output.xml and remove from branch**
- **feat(install): unify duplicate-file policy across install paths; use dedupe+skip for manifest installs; warn and skip on collision; harden prune removals**
- **docs(install): document unified duplicate-file policy and behavior for CLI and manifest installs**
- **perf(install): batch lockfile update during prune in install_all; save once per plugin instead of per file**
- **test(git): hermetic test for get_latest_remote_commit using local bare remote and clone; ensures fetch/credentials flow works offline**
- **feat(install): bound clone concurrency by PEZ_JOBS using for_each_concurrent; keep file copy sequential with dedupe**
- **feat(upgrade): respect selectors from pez.toml (version/branch/tag/commit); resolve via resolver and fall back to remote HEAD on error**
- **feat(list): add --filter [all|local|remote]; include selector column in table and json; avoid short-SHA slicing with char-safe short7()**
- **feat(uninstall): add --stdin to read repos from stdin; keeps args list support and merges both**
- **feat(env): support PEZ_TARGET_DIR to override destination config dir; update README and docs**
- **ci(release): add GitHub Actions workflow to build/test on tag push and upload artifacts**
- **docs(install): GitHub Releases のバイナリ入手方法を追記; CIリリースの注意点を補足**
