### PR TITLE
feat: add runtime-configurable shell hook controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ state in a lockfile.
 - Lockfile with exact commits and installed file records
 - Duplicate destination detection to avoid overwrites
 - `upgrade`, `prune`, and `doctor` utilities
-- Optional activation wrapper to emit conf.d events in the current shell
+- Optional, runtime-configured shell hooks for `conf.d`
 
 ## Installation
 
@@ -64,7 +64,7 @@ pez list --format table
 # 5) (Optional) Enable completions for pez itself
 pez completions fish > ~/.config/fish/completions/pez.fish
 
-# 6) (Optional) Activate fish shell hooks (emit conf.d events in the current shell)
+# 6) (Optional) Activate the fish shell wrapper
 pez activate fish | source
 ```
 
@@ -79,11 +79,23 @@ Completions are intentionally Fish-only.
 ## Shell Activation
 
 ```fish
-# Enable conf.d events in the current shell for install/upgrade/uninstall
+# Install a wrapper that checks the current hook config at runtime
 pez activate fish | source
 ```
 
 For persistence, add it inside an `if status is-interactive ... end` block in `~/.config/fish/config.fish`.
+
+By default, pez keeps shell hooks disabled:
+
+```toml
+[shell_hooks]
+emit = false
+source = false
+```
+
+Enable `emit` and/or `source` in `pez.toml` when you want fisher-like `conf.d`
+hook behavior. `pez activate fish` reads that config at execution time, so you
+do not need to regenerate the wrapper after editing `pez.toml`.
 
 ## Docs & FAQ
 
@@ -115,7 +127,7 @@ Details: [docs/migrate-from-fisher.md](docs/migrate-from-fisher.md)
 Usage: pez [OPTIONS] <COMMAND>
 
 Commands:
-  init | install | uninstall | upgrade | list | prune | completions | activate | doctor | migrate | files
+  init | install | uninstall | upgrade | list | prune | completions | activate | hook-config | doctor | migrate | files
 
 Options:
   -v, --verbose  Increase output verbosity (-v for info, -vv for debug)
@@ -163,9 +175,12 @@ clones), see [docs/commands.md](docs/commands.md).
 
 ## Security
 
-pez installs plugin files from third-party repositories. If you enable the
-activation wrapper, `conf.d` scripts are sourced in the current shell. pez does
-not verify signatures or sandbox code. Only install plugins you trust.
+pez installs plugin files from third-party repositories. Even with
+`shell_hooks.emit = false` and `shell_hooks.source = false`, copied `conf.d`
+files can still run when Fish later loads them. If you enable the activation
+wrapper with `shell_hooks.source = true`, pez will also source matching `conf.d`
+files in the current shell. pez does not verify signatures or sandbox code.
+Only install plugins you trust.
 
 ## Contributing
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,6 +1,22 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
+  "definitions": {
+    "ShellHooksConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "emit": {
+          "default": false,
+          "type": "boolean"
+        },
+        "source": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    }
+  },
   "properties": {
     "plugins": {
       "items": {
@@ -140,6 +156,17 @@
         "type": "object"
       },
       "type": "array"
+    },
+    "shell_hooks": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ShellHooksConfig"
+        }
+      ],
+      "default": {
+        "emit": false,
+        "source": false
+      }
     }
   },
   "title": "pez config",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,8 @@ This document outlines the high‑level structure and flows in pez.
   - `git.rs`: resolve selections against a repo (branches/tags/commits), list tags.
   - `utils.rs`: path/env resolution, copy routines, events, helpers.
   - `cmd/*`: end‑user commands orchestrating core modules.
-    - `cmd/activate.rs`: emits Fish wrapper code to run hooks in the current shell.
+    - `cmd/activate.rs`: emits Fish wrapper code that consults runtime hook config.
+    - `cmd/hook_config.rs`: resolves the effective shell hook config for wrappers and diagnostics.
     - `cmd/files.rs`: lists installed file paths from the lockfile (used by activation).
 
 ## Data Flow (install)
@@ -24,7 +25,7 @@ This document outlines the high‑level structure and flows in pez.
 4. Resolve the commit using `resolver::RefKind` -> `git::resolve_selection`.
 5. Copy files to the Fish config directory using `utils::copy_plugin_files*`.
 6. Update the lockfile with `name`/`repo`/`source`/`commit_sha`/`files`.
-7. For files under `conf.d`, emit `fish -c 'emit <stem>_{install|update|uninstall}'` events.
+7. For files under `conf.d`, optionally emit `fish -c 'emit <stem>_{install|update|uninstall}'` when `shell_hooks.emit` (or a command override) is enabled.
 
 ## Concurrency
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -13,6 +13,7 @@
   - [doctor](#doctor)
   - [completions](#completions)
   - [activate](#activate)
+  - [hook-config](#hook-config)
   - [files](#files)
   - [migrate](#migrate)
 
@@ -44,6 +45,7 @@ Global options (apply to all commands)
 - Options:
   - `--force` Reinstall even if the target already exists.
   - `--prune` (only available when running without explicit targets) removes lockfile entries that are no longer declared in `pez.toml` after a successful install.
+  - `--emit-hooks` / `--no-emit-hooks` override `shell_hooks.emit` for this command.
 - Behavior:
   - CLI‑specified targets are appended to `pez.toml`; relative paths and `~/` are normalized to absolute paths before writing.
   - `owner/repo` resolves to `https://github.com/owner/repo`; `host/...` without a scheme is normalized to `https://host/...`.
@@ -62,6 +64,7 @@ Global options (apply to all commands)
 - Options:
   - `--force` Remove files recorded in the lockfile even if the repository directory is missing.
   - `--stdin` Read `owner/repo` or `host/owner/repo` values from stdin. Blank lines and lines starting with `#` are ignored; the remaining entries are sorted and deduplicated before processing.
+  - `--emit-hooks` / `--no-emit-hooks` override `shell_hooks.emit` for this command.
 - Behavior: removes the cloned repository (if present) and the files recorded in `pez-lock.toml`, then removes the matching entry from `pez.toml` to keep the configuration in sync. Without `--force` when the repo directory is missing, the command prints the target files and exits.
 - Example:
   - `printf "owner/a\nowner/b\n" | pez uninstall --stdin`
@@ -72,6 +75,7 @@ Global options (apply to all commands)
 - Respects selectors in `pez.toml` (`version`/`branch`/`tag`/`commit`). When no selector is set, updates to the latest commit on the remote default branch (remote HEAD).
 - Local path sources (`path`) are skipped.
 - Concurrency is controlled by `--jobs` or `PEZ_JOBS`.
+- `--emit-hooks` / `--no-emit-hooks` override `shell_hooks.emit` for this command.
 - Any repo specified on the CLI that is not already in `pez.toml` is added automatically so future installs remain in sync.
 
 ### list
@@ -97,6 +101,9 @@ Global options (apply to all commands)
 
 - Checks the configuration file, lockfile, data/config directories, and the set of copied files.
 - Reported checks include: `config`, `lock_file`, `fish_config_dir`, `pez_data_dir`, `activate_configured`, `event_hook_readiness`, `install_layout`, `repos` (missing clones), `target_files` (missing files), `duplicates` (conflicting destinations), `theme_assets`.
+- Hook-related behavior:
+  - when both `shell_hooks.emit` and `shell_hooks.source` are disabled, `doctor` reports that shell hooks are intentionally disabled.
+  - when `shell_hooks.source` is enabled but the activate wrapper is not detected, `doctor` warns.
 - Options: `--format json`.
 
 ### completions
@@ -108,8 +115,26 @@ Global options (apply to all commands)
 
 - Output shell activation code that wraps `pez` with hooks in the current shell.
 - Usage: `pez activate fish | source` (for persistence, add inside `if status is-interactive ... end` in `~/.config/fish/config.fish`).
-- Behavior: after `install`/`upgrade`, sources matching `conf.d` files and emits `<stem>_{install|update}` in the current shell; before `uninstall`, emits `<stem>_uninstall`.
+- Options:
+  - `--emit-hooks` / `--no-emit-hooks` override `shell_hooks.emit` inside the wrapper.
+  - `--source-hooks` / `--no-source-hooks` override `shell_hooks.source` inside the wrapper.
+- Behavior:
+  - the wrapper queries `pez hook-config` at runtime, so edits to `pez.toml` are picked up without re-running `pez activate fish | source`.
+  - after `install`/`upgrade`, it can source matching `conf.d` files and emit `<stem>_{install|update}` in the current shell.
+  - before `uninstall`, it can emit `<stem>_uninstall` and optionally source matching files, depending on the resolved hook config.
 - When active, the wrapper runs `pez` with `PEZ_SUPPRESS_EMIT=1` to avoid duplicate out-of-process emits.
+
+### hook-config
+
+- Show the effective shell hook configuration after applying `pez.toml` defaults and optional CLI overrides.
+- Options:
+  - `--format json`
+  - `--emit-hooks` / `--no-emit-hooks`
+  - `--source-hooks` / `--no-source-hooks`
+  - `--from [install|update|upgrade|uninstall|remove]` parses a subcommand argv after `--` and applies any command-specific hook overrides.
+- Examples:
+  - `pez hook-config --format json`
+  - `pez hook-config --from install -- --emit-hooks owner/repo`
 
 ### files
 
@@ -135,4 +160,5 @@ Global options (apply to all commands)
 - `--force` replaces the existing plugin list with the migrated entries instead of merging.
 - `--install` triggers `pez install` for the migrated entries after they are written (skipped when `--dry-run` is set).
 - The command always prints "Next steps" guidance (install/verify/doctor/activate flow) so you can continue migration safely.
+- If you want fisher-like `conf.d` hook behavior during migration, enable `[shell_hooks]` and source `pez activate fish | source` before continuing.
 - Recommended migration flow is documented in [migrate-from-fisher.md](migrate-from-fisher.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -112,22 +112,43 @@ Notes
 - For local sources, `commit_sha = "local"`. Such entries are skipped by
   `upgrade` and excluded from `list --outdated` comparisons.
 
+## Shell Hooks
+
+Use `[shell_hooks]` in `pez.toml` to control optional `conf.d` hook behavior.
+
+```toml
+[shell_hooks]
+emit = false
+source = false
+```
+
+- `emit` controls whether `pez install` / `upgrade` / `uninstall` emit
+  `emit <stem>_{install|update|uninstall}` for `conf.d` files.
+- `source` controls whether the Fish activation wrapper sources matching
+  `conf.d` files in the current shell.
+- Both default to `false`.
+- `pez activate fish | source` reads the current config each time it runs a
+  wrapped command, so changing `pez.toml` takes effect without regenerating the
+  wrapper.
+
 ## Plugin Layout and Copy Rules
 
 - pez looks for top-level `functions`, `completions`, `conf.d`, and `themes` directories in each plugin repo.
 - It copies files recursively into the matching Fish config directories, preserving relative paths.
 - Only `.fish` files are copied from `functions`/`completions`/`conf.d`, and only `.theme` files from `themes`.
 - If two plugins would write the same destination path in a single run, the later plugin is skipped and its files are not recorded in the lockfile.
-- For `conf.d` files, pez emits `emit <stem>_{install|update|uninstall}` after installs/upgrades or before uninstalls (unless `PEZ_SUPPRESS_EMIT` is set).
+- Copying `conf.d` files is separate from hook execution. pez always copies matching files, but only emits `emit <stem>_{install|update|uninstall}` when `shell_hooks.emit` is enabled (or a command-level override is used).
 
 ## Environment Variables and CLI Overrides
 
 - `PEZ_CONFIG_DIR` — Directory containing `pez.toml` and `pez-lock.toml`.
 - `PEZ_DATA_DIR` — Base directory for cloned plugin repositories.
 - `PEZ_TARGET_DIR` — Override the Fish config directory used for copying plugin files. It no longer changes where `pez.toml` or `pez-lock.toml` live.
-- `PEZ_SUPPRESS_EMIT` — When set, suppress `fish -c 'emit ...'` hooks during install/upgrade/uninstall. Used by `pez activate fish` to avoid duplicate events.
+- `PEZ_SUPPRESS_EMIT` — Internal override used by `pez activate fish` to suppress duplicate out-of-process emits while the wrapper handles hooks in-process.
 - `__fish_config_dir` / `XDG_CONFIG_HOME` — Fish configuration directory.
 - `__fish_user_data_dir` / `XDG_DATA_HOME` — Fish data directory.
+- `install` / `upgrade` / `uninstall` support `--emit-hooks` and `--no-emit-hooks` to override `shell_hooks.emit` for a single command.
+- `activate` supports `--emit-hooks`, `--no-emit-hooks`, `--source-hooks`, and `--no-source-hooks` to bake wrapper-local overrides on top of runtime config.
 - `--jobs <N>` — Global CLI flag to override concurrency for `install` (explicit
   targets), `upgrade`, `uninstall`, and `prune`. Must be a positive integer.
 - `PEZ_JOBS` — Environment override for the same concurrency (default: 4). Ignored

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,7 +26,34 @@ Use `pez files owner/repo` for a single plugin or `pez files --all` for everythi
 
 ### How do I run conf.d hooks in my current shell?
 
-Source the activation script: `pez activate fish | source`. For persistence, place it in `~/.config/fish/config.fish` inside `if status is-interactive ... end`. This wraps `pez` so `install`/`upgrade`/`uninstall` source the affected conf.d files and emit events in the current shell.
+Enable hooks in `pez.toml`, then source the activation script:
+
+```toml
+[shell_hooks]
+emit = true
+source = true
+```
+
+```fish
+pez activate fish | source
+```
+
+For persistence, place it in `~/.config/fish/config.fish` inside
+`if status is-interactive ... end`. The wrapper reads `pez.toml` at runtime, so
+changing `shell_hooks` takes effect without regenerating it.
+
+### Can I disable hook execution?
+
+Yes. The default is already:
+
+```toml
+[shell_hooks]
+emit = false
+source = false
+```
+
+You can also temporarily override emit behavior per command with
+`--emit-hooks` or `--no-emit-hooks`.
 
 ### How do I uninstall everything not in pez.toml?
 

--- a/docs/migrate-from-fisher.md
+++ b/docs/migrate-from-fisher.md
@@ -4,41 +4,60 @@ This guide provides a low-risk migration path from `fisher` to `pez`.
 
 ## Recommended path
 
-1. Enable activation in your current shell.
+1. Decide whether you want fisher-like runtime hooks.
+
+By default, pez keeps shell hooks disabled:
+
+```toml
+[shell_hooks]
+emit = false
+source = false
+```
+
+If you want current-shell `conf.d` sourcing and event emission similar to
+fisher, enable them first:
+
+```toml
+[shell_hooks]
+emit = true
+source = true
+```
+
+2. Enable activation in your current shell if you turned on `shell_hooks.source`.
 
 ```fish
 pez activate fish | source
 ```
 
-2. Import `fish_plugins` into `pez.toml`.
+3. Import `fish_plugins` into `pez.toml`.
 
 ```fish
 pez migrate
 ```
 
-3. Install migrated plugins.
+4. Install migrated plugins.
 
 ```fish
 pez install
 ```
 
-4. Verify the result.
+5. Verify the result.
 
 ```fish
 pez list --format table
 pez doctor
 ```
 
-5. Remove or disable fisher after verification.
+6. Remove or disable fisher after verification.
 
 ## Common pitfalls
 
-- `pez activate fish` is not enabled:
-  `install`/`upgrade`/`uninstall` complete, but in-process `conf.d` events are not emitted in the current shell.
+- `pez activate fish` alone does not enable hooks:
+  the wrapper reads `pez.toml` at runtime; if `shell_hooks.emit` / `shell_hooks.source` remain `false`, no current-shell hook actions run.
 - `fisher` itself was removed during migration:
   this is expected; `jorgebucaran/fisher` is skipped by `pez migrate`.
 - `conf.d` behavior differs before activation:
-  without activation wrapper, hooks are emitted out-of-process and may not affect the current interactive shell session.
+  with default settings, pez only copies plugin files. If you enable `shell_hooks.emit` without `shell_hooks.source`, events run out-of-process and may not affect the current interactive shell session.
 
 ## What pez handles (and does not)
 

--- a/src/bin/gen_config_schema.rs
+++ b/src/bin/gen_config_schema.rs
@@ -41,4 +41,17 @@ mod tests {
         assert!(generated.contains("\"$schema\""));
         assert!(generated.contains("\"plugins\""));
     }
+
+    #[test]
+    fn checked_in_schema_matches_generated_content() {
+        let output_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config.schema.json");
+        let checked_in = fs::read_to_string(&output_path).expect("read checked-in schema");
+        let generated = pez::schema::generate_config_schema().expect("generate schema");
+        let rendered = format!(
+            "{}\n",
+            serde_json::to_string_pretty(&generated).expect("serialize generated schema")
+        );
+
+        assert_eq!(checked_in, rendered);
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,6 +57,9 @@ pub(crate) enum Commands {
     /// Output shell activation code
     Activate(ActivateArgs),
 
+    /// Show the effective shell hook configuration
+    HookConfig(HookConfigArgs),
+
     /// Diagnose common setup issues
     Doctor(DoctorArgs),
 
@@ -79,6 +82,14 @@ pub(crate) struct InstallArgs {
     /// Prune uninstalled plugins
     #[arg(short, long, conflicts_with = "plugins")]
     pub(crate) prune: bool,
+
+    /// Enable out-of-process conf.d emit hooks for this command
+    #[arg(long, overrides_with = "no_emit_hooks")]
+    pub(crate) emit_hooks: bool,
+
+    /// Disable out-of-process conf.d emit hooks for this command
+    #[arg(long, overrides_with = "emit_hooks")]
+    pub(crate) no_emit_hooks: bool,
 }
 
 #[derive(Args, Debug)]
@@ -93,12 +104,28 @@ pub(crate) struct UninstallArgs {
     /// Read plugin repos from stdin (one per line)
     #[arg(long)]
     pub(crate) stdin: bool,
+
+    /// Enable out-of-process conf.d emit hooks for this command
+    #[arg(long, overrides_with = "no_emit_hooks")]
+    pub(crate) emit_hooks: bool,
+
+    /// Disable out-of-process conf.d emit hooks for this command
+    #[arg(long, overrides_with = "emit_hooks")]
+    pub(crate) no_emit_hooks: bool,
 }
 
 #[derive(Args, Debug)]
 pub(crate) struct UpgradeArgs {
     /// Repo in the format `owner/repo` or `host/owner/repo`
     pub(crate) plugins: Option<Vec<crate::models::PluginRepo>>,
+
+    /// Enable out-of-process conf.d emit hooks for this command
+    #[arg(long, overrides_with = "no_emit_hooks")]
+    pub(crate) emit_hooks: bool,
+
+    /// Disable out-of-process conf.d emit hooks for this command
+    #[arg(long, overrides_with = "emit_hooks")]
+    pub(crate) no_emit_hooks: bool,
 }
 
 #[derive(Args, Debug)]
@@ -206,6 +233,22 @@ pub(crate) struct ActivateArgs {
     /// Target shell for activation code
     #[arg(value_enum)]
     pub(crate) shell: ShellType,
+
+    /// Enable conf.d emit hooks inside the activation wrapper
+    #[arg(long, overrides_with = "no_emit_hooks")]
+    pub(crate) emit_hooks: bool,
+
+    /// Disable conf.d emit hooks inside the activation wrapper
+    #[arg(long, overrides_with = "emit_hooks")]
+    pub(crate) no_emit_hooks: bool,
+
+    /// Enable conf.d sourcing inside the activation wrapper
+    #[arg(long, overrides_with = "no_source_hooks")]
+    pub(crate) source_hooks: bool,
+
+    /// Disable conf.d sourcing inside the activation wrapper
+    #[arg(long, overrides_with = "source_hooks")]
+    pub(crate) no_source_hooks: bool,
 }
 
 #[derive(Args, Debug)]
@@ -218,6 +261,51 @@ pub(crate) struct DoctorArgs {
 #[derive(clap::ValueEnum, Clone, Debug)]
 pub(crate) enum DoctorFormat {
     Json,
+}
+
+#[derive(clap::ValueEnum, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum HookConfigFormat {
+    Json,
+}
+
+#[derive(clap::ValueEnum, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum HookConfigFrom {
+    Install,
+    Update,
+    Upgrade,
+    Uninstall,
+    Remove,
+}
+
+#[derive(Args, Debug, Clone)]
+pub(crate) struct HookConfigArgs {
+    /// Output format
+    #[arg(long, value_enum, default_value = "json")]
+    pub(crate) format: HookConfigFormat,
+
+    /// Enable conf.d emit hooks for this query
+    #[arg(long, overrides_with = "no_emit_hooks")]
+    pub(crate) emit_hooks: bool,
+
+    /// Disable conf.d emit hooks for this query
+    #[arg(long, overrides_with = "emit_hooks")]
+    pub(crate) no_emit_hooks: bool,
+
+    /// Enable conf.d sourcing for this query
+    #[arg(long, overrides_with = "no_source_hooks")]
+    pub(crate) source_hooks: bool,
+
+    /// Disable conf.d sourcing for this query
+    #[arg(long, overrides_with = "source_hooks")]
+    pub(crate) no_source_hooks: bool,
+
+    /// Derive subcommand-specific overrides by parsing argv for a subcommand
+    #[arg(long, value_enum)]
+    pub(crate) from: Option<HookConfigFrom>,
+
+    /// Arguments intended for the subcommand when using --from
+    #[arg(last = true)]
+    pub(crate) passthrough: Vec<String>,
 }
 
 // Types moved to models.rs: PluginRepo, InstallTarget, ResolvedInstallTarget
@@ -531,6 +619,41 @@ mod tests {
     #[test]
     fn jobs_override_rejects_zero() {
         assert!(Cli::try_parse_from(["pez", "--jobs", "0", "list"]).is_err());
+    }
+
+    #[test]
+    fn parse_install_emit_hook_flags() {
+        let cli = Cli::parse_from(["pez", "install", "--emit-hooks", "o/r"]);
+        match cli.command {
+            Commands::Install(args) => {
+                assert!(args.emit_hooks);
+                assert!(!args.no_emit_hooks);
+            }
+            other => panic!("expected install command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_hook_config_from_install_passthrough() {
+        let cli = Cli::parse_from([
+            "pez",
+            "hook-config",
+            "--from",
+            "install",
+            "--",
+            "--emit-hooks",
+            "o/r",
+        ]);
+        match cli.command {
+            Commands::HookConfig(args) => {
+                assert!(matches!(args.from, Some(HookConfigFrom::Install)));
+                assert_eq!(
+                    args.passthrough,
+                    vec!["--emit-hooks".to_string(), "o/r".to_string()]
+                );
+            }
+            other => panic!("expected hook-config command, got {other:?}"),
+        }
     }
 }
 

--- a/src/cmd/activate.rs
+++ b/src/cmd/activate.rs
@@ -1,15 +1,35 @@
+use crate::cli::ActivateArgs;
+
 /// Fish activation script emitter.
 ///
 /// Prints Fish wrapper code to stdout. Keep stdout clean of logs so it can be
 /// piped into `source`.
-pub(crate) fn run_fish() -> String {
-    let script = fish_script();
+pub(crate) fn run_fish(args: &ActivateArgs) -> String {
+    let script = fish_script(args);
     print!("{script}");
     script
 }
 
-fn fish_script() -> String {
+fn activation_hook_override_args(args: &ActivateArgs) -> String {
+    let mut flags = Vec::new();
+    if args.emit_hooks {
+        flags.push("--emit-hooks");
+    }
+    if args.no_emit_hooks {
+        flags.push("--no-emit-hooks");
+    }
+    if args.source_hooks {
+        flags.push("--source-hooks");
+    }
+    if args.no_source_hooks {
+        flags.push("--no-source-hooks");
+    }
+    flags.join(" ")
+}
+
+fn fish_script(args: &ActivateArgs) -> String {
     let version = env!("CARGO_PKG_VERSION");
+    let hook_override_args = activation_hook_override_args(args);
     // Guard against multiple sourcing and wrap pez to emit events in-process.
     format!(
         r#"
@@ -53,13 +73,27 @@ if not set -q __pez_activate_version; or test "$__pez_activate_version" != "$__p
     end
 
     function __pez_fish_source_and_emit --description "Source conf.d and emit events" --argument-names phase from
+        set -l __pez_hook_config_args {hook_override_args}
         set -l passthrough $argv[3..-1]
+        set -l hook_config (command pez hook-config --format json --from $from $__pez_hook_config_args -- $passthrough)
+        set -l source_enabled 0
+        set -l emit_enabled 0
+        if string match -rq '.*"source"[[:space:]]*:[[:space:]]*true.*' -- $hook_config
+            set source_enabled 1
+        end
+        if string match -rq '.*"emit"[[:space:]]*:[[:space:]]*true.*' -- $hook_config
+            set emit_enabled 1
+        end
         set -l paths (command pez files --dir conf.d --from $from -- $passthrough | sort)
         for path in $paths
             if test -f "$path"
-                source "$path"
-                set -l name (basename "$path" .fish)
-                emit "$name"_"$phase"
+                if test $source_enabled -eq 1
+                    source "$path"
+                end
+                if test $emit_enabled -eq 1
+                    set -l name (basename "$path" .fish)
+                    emit "$name"_"$phase"
+                end
             end
         end
     end
@@ -111,21 +145,33 @@ end
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::ShellType;
+
+    fn activate_args() -> ActivateArgs {
+        ActivateArgs {
+            shell: ShellType::Fish,
+            emit_hooks: false,
+            no_emit_hooks: false,
+            source_hooks: false,
+            no_source_hooks: false,
+        }
+    }
 
     #[test]
     fn script_contains_guard_and_suppress_flag() {
-        let text = fish_script();
+        let text = fish_script(&activate_args());
         assert!(text.contains("__pez_activate_version"));
         assert!(text.contains("__pez_version"));
         assert!(text.contains(env!("CARGO_PKG_VERSION")));
         assert!(text.contains("PEZ_SUPPRESS_EMIT"));
         assert!(text.contains("command pez files --dir conf.d --from"));
+        assert!(text.contains("command pez hook-config --format json --from"));
         assert!(text.contains("__pez_fish_split_subcmd"));
     }
 
     #[test]
     fn uninstall_emits_before_command() {
-        let text = fish_script();
+        let text = fish_script(&activate_args());
         let parts: Vec<&str> = text.split("case uninstall remove").collect();
         assert!(parts.len() > 1, "uninstall case missing");
         let segment = parts[1];
@@ -144,7 +190,7 @@ mod tests {
     #[test]
     fn targets_not_dropped() {
         // ensure we don't slice away the first target (no custom filter function)
-        let text = fish_script();
+        let text = fish_script(&activate_args());
         assert!(!text.contains("__pez_fish_filter_targets"));
         assert!(text.contains("set -l subargs $parsed[2..-1]"));
         assert!(text.contains("__pez_fish_source_and_emit install install $subargs"));
@@ -153,7 +199,7 @@ mod tests {
 
     #[test]
     fn global_flags_are_skipped() {
-        let text = fish_script();
+        let text = fish_script(&activate_args());
         assert!(text.contains("--jobs"));
         assert!(text.contains("--jobs=*"));
         assert!(text.contains("--verbose"));
@@ -162,7 +208,7 @@ mod tests {
 
     #[test]
     fn uninstall_stdin_is_tapped() {
-        let text = fish_script();
+        let text = fish_script(&activate_args());
         assert!(text.contains("contains -- --stdin $subargs"));
         assert!(text.contains("psub -f -s .pez_uninstall"));
         assert!(text.contains("cat $stdin_file | __pez_fish_source_and_emit uninstall"));
@@ -171,9 +217,30 @@ mod tests {
 
     #[test]
     fn run_fish_returns_script() {
-        let script = run_fish();
-        assert_eq!(script, fish_script());
+        let args = activate_args();
+        let script = run_fish(&args);
+        assert_eq!(script, fish_script(&args));
         assert!(script.contains("__pez_activate_version"));
         assert!(script.contains("function pez --wraps pez"));
+    }
+
+    #[test]
+    fn wrapper_queries_hook_config_at_runtime() {
+        let text = fish_script(&activate_args());
+        assert!(text.contains("set -l hook_config (command pez hook-config --format json --from"));
+        assert!(text.contains("string match -rq '.*\"source\""));
+        assert!(text.contains("string match -rq '.*\"emit\""));
+    }
+
+    #[test]
+    fn script_embeds_activation_hook_overrides() {
+        let text = fish_script(&ActivateArgs {
+            shell: ShellType::Fish,
+            emit_hooks: true,
+            no_emit_hooks: false,
+            source_hooks: false,
+            no_source_hooks: true,
+        });
+        assert!(text.contains("set -l __pez_hook_config_args --emit-hooks --no-source-hooks"));
     }
 }

--- a/src/cmd/doctor.rs
+++ b/src/cmd/doctor.rs
@@ -1,4 +1,4 @@
-use crate::{cli, lock_file::LockFile, models::TargetDir, utils};
+use crate::{cli, config, lock_file::LockFile, models::TargetDir, utils};
 use serde_derive::Serialize;
 use serde_json::json;
 use std::{collections::HashSet, fs, path};
@@ -34,13 +34,17 @@ pub(crate) fn run(args: &cli::DoctorArgs) -> anyhow::Result<Vec<DoctorCheck>> {
 
 fn collect_checks() -> anyhow::Result<Vec<DoctorCheck>> {
     let mut checks: Vec<DoctorCheck> = Vec::new();
+    let mut shell_hooks = config::ShellHooksConfig::default();
 
     match utils::load_config() {
-        Ok((_cfg, path)) => checks.push(DoctorCheck {
-            name: "config",
-            status: "ok",
-            details: format!("found: {}", path.display()),
-        }),
+        Ok((cfg, path)) => {
+            shell_hooks = cfg.shell_hooks;
+            checks.push(DoctorCheck {
+                name: "config",
+                status: "ok",
+                details: format!("found: {}", path.display()),
+            })
+        }
         Err(_) => checks.push(DoctorCheck {
             name: "config",
             status: "warn",
@@ -85,10 +89,10 @@ fn collect_checks() -> anyhow::Result<Vec<DoctorCheck>> {
 
     // Activation is configured in the user's fish config directory, not the install target.
     let fish_runtime_config_dir = utils::load_default_fish_config_dir()?;
-    let activate_check = check_activate_configured(&fish_runtime_config_dir);
+    let activate_check = check_activate_configured(&fish_runtime_config_dir, shell_hooks);
     let activation_enabled = activate_check.status == "ok";
     checks.push(activate_check);
-    checks.push(check_event_hook_readiness(activation_enabled));
+    checks.push(check_event_hook_readiness(activation_enabled, shell_hooks));
     checks.push(check_install_layout(&fish_config_dir));
 
     if let Some(lock_file) = lock {
@@ -155,7 +159,18 @@ fn collect_checks() -> anyhow::Result<Vec<DoctorCheck>> {
     Ok(checks)
 }
 
-fn check_activate_configured(fish_config_dir: &path::Path) -> DoctorCheck {
+fn check_activate_configured(
+    fish_config_dir: &path::Path,
+    shell_hooks: config::ShellHooksConfig,
+) -> DoctorCheck {
+    if !shell_hooks.source {
+        return DoctorCheck {
+            name: "activate_configured",
+            status: "ok",
+            details: "not required; shell_hooks.source is disabled".to_string(),
+        };
+    }
+
     let config_fish_path = fish_config_dir.join("config.fish");
     if !config_fish_path.exists() {
         return DoctorCheck {
@@ -202,20 +217,40 @@ fn has_activate_fish_line(contents: &str) -> bool {
     })
 }
 
-fn check_event_hook_readiness(activation_enabled: bool) -> DoctorCheck {
-    if activation_enabled {
+fn check_event_hook_readiness(
+    activation_enabled: bool,
+    shell_hooks: config::ShellHooksConfig,
+) -> DoctorCheck {
+    if !shell_hooks.emit && !shell_hooks.source {
         return DoctorCheck {
             name: "event_hook_readiness",
             status: "ok",
-            details: "activate wrapper detected; conf.d events should run in the current shell"
-                .to_string(),
+            details: "shell hooks are disabled by config (emit=false, source=false)".to_string(),
         };
+    }
+
+    if shell_hooks.source && !activation_enabled {
+        return DoctorCheck {
+            name: "event_hook_readiness",
+            status: "warn",
+            details:
+                "shell_hooks.source is enabled, but activate wrapper is not detected; run `pez activate fish | source`"
+                    .to_string(),
+        };
+    }
+
+    let mut enabled = Vec::new();
+    if shell_hooks.source {
+        enabled.push("source");
+    }
+    if shell_hooks.emit {
+        enabled.push("emit");
     }
 
     DoctorCheck {
         name: "event_hook_readiness",
-        status: "warn",
-        details: "activate wrapper not detected; run `pez activate fish | source`".to_string(),
+        status: "ok",
+        details: format!("enabled hook actions: {}", enabled.join(", ")),
     }
 }
 
@@ -457,14 +492,14 @@ mod tests {
     }
 
     #[test]
-    fn doctor_warns_when_activate_is_not_configured() {
+    fn doctor_treats_disabled_shell_hooks_as_ok() {
         let mut env = TestEnvironmentSetup::new();
         env.setup_config(config::init());
 
         with_env(&env, || {
             let statuses = status_map(collect_checks().unwrap());
-            assert_eq!(statuses.get("activate_configured"), Some(&"warn"));
-            assert_eq!(statuses.get("event_hook_readiness"), Some(&"warn"));
+            assert_eq!(statuses.get("activate_configured"), Some(&"ok"));
+            assert_eq!(statuses.get("event_hook_readiness"), Some(&"ok"));
             assert_eq!(statuses.get("install_layout"), Some(&"ok"));
         });
     }
@@ -502,6 +537,79 @@ mod tests {
             let statuses = status_map(collect_checks().unwrap());
             assert_eq!(statuses.get("activate_configured"), Some(&"ok"));
             assert_eq!(statuses.get("event_hook_readiness"), Some(&"ok"));
+        });
+    }
+
+    #[test]
+    fn doctor_reports_event_hooks_ready_when_activate_and_shell_hooks_are_enabled() {
+        let mut env = TestEnvironmentSetup::new();
+        env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig {
+                emit: true,
+                source: true,
+            },
+            plugins: None,
+        });
+        std::fs::write(
+            env.fish_config_dir.join("config.fish"),
+            "if status is-interactive\n    pez activate fish | source\nend\n",
+        )
+        .unwrap();
+
+        with_env(&env, || {
+            let statuses = status_map(collect_checks().unwrap());
+            assert_eq!(statuses.get("activate_configured"), Some(&"ok"));
+            assert_eq!(statuses.get("event_hook_readiness"), Some(&"ok"));
+        });
+    }
+
+    #[test]
+    fn doctor_warns_when_source_hooks_are_enabled_without_activate_wrapper() {
+        let mut env = TestEnvironmentSetup::new();
+        env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig {
+                emit: false,
+                source: true,
+            },
+            plugins: None,
+        });
+
+        with_env(&env, || {
+            let statuses = status_map(collect_checks().unwrap());
+            assert_eq!(statuses.get("activate_configured"), Some(&"warn"));
+            assert_eq!(statuses.get("event_hook_readiness"), Some(&"warn"));
+        });
+    }
+
+    #[test]
+    fn doctor_reports_emit_only_hooks_as_enabled() {
+        let mut env = TestEnvironmentSetup::new();
+        env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig {
+                emit: true,
+                source: false,
+            },
+            plugins: None,
+        });
+
+        with_env(&env, || {
+            let checks = collect_checks().unwrap();
+            let activate = checks
+                .iter()
+                .find(|check| check.name == "activate_configured")
+                .expect("activate_configured check missing");
+            assert_eq!(activate.status, "ok");
+            assert_eq!(
+                activate.details,
+                "not required; shell_hooks.source is disabled"
+            );
+
+            let event = checks
+                .iter()
+                .find(|check| check.name == "event_hook_readiness")
+                .expect("event_hook_readiness check missing");
+            assert_eq!(event.status, "ok");
+            assert_eq!(event.details, "enabled hook actions: emit");
         });
     }
 

--- a/src/cmd/hook_config.rs
+++ b/src/cmd/hook_config.rs
@@ -1,0 +1,284 @@
+use crate::cli::{Cli, Commands, HookConfigArgs, HookConfigFormat, HookConfigFrom};
+use crate::utils;
+use anyhow::anyhow;
+use clap::Parser;
+use clap::error::ErrorKind;
+
+pub(crate) fn run(args: &HookConfigArgs) -> anyhow::Result<crate::config::ShellHooksConfig> {
+    let shell_hooks = collect_hook_config(args)?;
+    match args.format {
+        HookConfigFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&shell_hooks)?);
+        }
+    }
+    Ok(shell_hooks)
+}
+
+fn collect_hook_config(args: &HookConfigArgs) -> anyhow::Result<crate::config::ShellHooksConfig> {
+    let mut override_value = utils::shell_hooks_override(
+        utils::resolve_bool_override(args.emit_hooks, args.no_emit_hooks),
+        utils::resolve_bool_override(args.source_hooks, args.no_source_hooks),
+    );
+
+    if let Some(from) = &args.from {
+        let from_override = hook_override_from_from_arg(from, &args.passthrough)?;
+        if let Some(value) = from_override.emit {
+            override_value.emit = Some(value);
+        }
+        if let Some(value) = from_override.source {
+            override_value.source = Some(value);
+        }
+    }
+
+    utils::resolve_shell_hooks_with_override(override_value)
+}
+
+fn hook_override_from_from_arg(
+    from: &HookConfigFrom,
+    passthrough: &[String],
+) -> anyhow::Result<utils::ShellHooksOverride> {
+    let argv = build_from_argv(from, passthrough);
+    let parsed = match Cli::try_parse_from(argv) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            if is_display_help_or_version(&err) {
+                return Ok(utils::ShellHooksOverride::default());
+            }
+            return Err(anyhow!(err.to_string()));
+        }
+    };
+
+    match parsed.command {
+        Commands::Install(args) => Ok(utils::shell_hooks_override(
+            utils::resolve_bool_override(args.emit_hooks, args.no_emit_hooks),
+            None,
+        )),
+        Commands::Upgrade(args) => Ok(utils::shell_hooks_override(
+            utils::resolve_bool_override(args.emit_hooks, args.no_emit_hooks),
+            None,
+        )),
+        Commands::Uninstall(args) => Ok(utils::shell_hooks_override(
+            utils::resolve_bool_override(args.emit_hooks, args.no_emit_hooks),
+            None,
+        )),
+        other => anyhow::bail!("Unsupported --from target: {:?}", other),
+    }
+}
+
+fn build_from_argv(from: &HookConfigFrom, passthrough: &[String]) -> Vec<String> {
+    let subcmd = match from {
+        HookConfigFrom::Install => "install",
+        HookConfigFrom::Update => "upgrade",
+        HookConfigFrom::Upgrade => "upgrade",
+        HookConfigFrom::Uninstall => "uninstall",
+        HookConfigFrom::Remove => "uninstall",
+    };
+
+    let mut argv = Vec::with_capacity(passthrough.len() + 2);
+    argv.push("pez".to_string());
+    argv.push(subcmd.to_string());
+    argv.extend_from_slice(passthrough);
+    argv
+}
+
+fn is_display_help_or_version(err: &clap::Error) -> bool {
+    matches!(
+        err.kind(),
+        ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config;
+    use crate::tests_support::env::TestEnvironmentSetup;
+    use crate::tests_support::log::env_lock;
+
+    fn with_env<F: FnOnce() -> anyhow::Result<()>>(env: &TestEnvironmentSetup, f: F) {
+        let _lock = env_lock().lock().unwrap();
+        let prev_pc = std::env::var_os("PEZ_CONFIG_DIR");
+        unsafe {
+            std::env::set_var("PEZ_CONFIG_DIR", &env.config_dir);
+        }
+        let result = f();
+        unsafe {
+            if let Some(v) = prev_pc {
+                std::env::set_var("PEZ_CONFIG_DIR", v);
+            } else {
+                std::env::remove_var("PEZ_CONFIG_DIR");
+            }
+        }
+        result.unwrap();
+    }
+
+    #[test]
+    fn collect_hook_config_uses_config_defaults() {
+        let mut env = TestEnvironmentSetup::new();
+        env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig {
+                emit: true,
+                source: false,
+            },
+            plugins: None,
+        });
+
+        with_env(&env, || {
+            let hooks = collect_hook_config(&HookConfigArgs {
+                format: HookConfigFormat::Json,
+                emit_hooks: false,
+                no_emit_hooks: false,
+                source_hooks: false,
+                no_source_hooks: false,
+                from: None,
+                passthrough: vec![],
+            })?;
+            assert!(hooks.emit);
+            assert!(!hooks.source);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn collect_hook_config_applies_direct_source_override() {
+        let mut env = TestEnvironmentSetup::new();
+        env.setup_config(config::init());
+
+        with_env(&env, || {
+            let hooks = collect_hook_config(&HookConfigArgs {
+                format: HookConfigFormat::Json,
+                emit_hooks: false,
+                no_emit_hooks: false,
+                source_hooks: true,
+                no_source_hooks: false,
+                from: None,
+                passthrough: vec![],
+            })?;
+            assert!(!hooks.emit);
+            assert!(hooks.source);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn collect_hook_config_from_install_passthrough_overrides_emit() {
+        let mut env = TestEnvironmentSetup::new();
+        env.setup_config(config::init());
+
+        with_env(&env, || {
+            let hooks = collect_hook_config(&HookConfigArgs {
+                format: HookConfigFormat::Json,
+                emit_hooks: false,
+                no_emit_hooks: false,
+                source_hooks: false,
+                no_source_hooks: false,
+                from: Some(HookConfigFrom::Install),
+                passthrough: vec!["--emit-hooks".into(), "owner/repo".into()],
+            })?;
+            assert!(hooks.emit);
+            assert!(!hooks.source);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn from_passthrough_overrides_direct_emit_override() {
+        let mut env = TestEnvironmentSetup::new();
+        env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig {
+                emit: true,
+                source: false,
+            },
+            plugins: None,
+        });
+
+        with_env(&env, || {
+            let hooks = collect_hook_config(&HookConfigArgs {
+                format: HookConfigFormat::Json,
+                emit_hooks: true,
+                no_emit_hooks: false,
+                source_hooks: false,
+                no_source_hooks: false,
+                from: Some(HookConfigFrom::Install),
+                passthrough: vec!["--no-emit-hooks".into(), "owner/repo".into()],
+            })?;
+            assert!(!hooks.emit);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn run_returns_non_default_config() {
+        let mut env = TestEnvironmentSetup::new();
+        env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig {
+                emit: true,
+                source: false,
+            },
+            plugins: None,
+        });
+
+        with_env(&env, || {
+            let hooks = run(&HookConfigArgs {
+                format: HookConfigFormat::Json,
+                emit_hooks: false,
+                no_emit_hooks: false,
+                source_hooks: false,
+                no_source_hooks: false,
+                from: None,
+                passthrough: vec![],
+            })?;
+            assert!(hooks.emit);
+            assert!(!hooks.source);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn collect_hook_config_errors_on_invalid_passthrough_args() {
+        let mut env = TestEnvironmentSetup::new();
+        env.setup_config(config::init());
+
+        with_env(&env, || {
+            let err = collect_hook_config(&HookConfigArgs {
+                format: HookConfigFormat::Json,
+                emit_hooks: false,
+                no_emit_hooks: false,
+                source_hooks: false,
+                no_source_hooks: false,
+                from: Some(HookConfigFrom::Install),
+                passthrough: vec!["--nope".into()],
+            })
+            .expect_err("invalid passthrough should fail");
+            assert!(err.to_string().contains("unexpected argument '--nope'"));
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn collect_hook_config_ignores_help_passthrough_args() {
+        let mut env = TestEnvironmentSetup::new();
+        env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig {
+                emit: true,
+                source: false,
+            },
+            plugins: None,
+        });
+
+        with_env(&env, || {
+            let hooks = collect_hook_config(&HookConfigArgs {
+                format: HookConfigFormat::Json,
+                emit_hooks: false,
+                no_emit_hooks: false,
+                source_hooks: false,
+                no_source_hooks: false,
+                from: Some(HookConfigFrom::Install),
+                passthrough: vec!["--help".into()],
+            })?;
+            assert!(hooks.emit);
+            assert!(!hooks.source);
+            Ok(())
+        });
+    }
+}

--- a/src/cmd/install.rs
+++ b/src/cmd/install.rs
@@ -24,20 +24,25 @@ pub(crate) async fn run(args: &InstallArgs) -> anyhow::Result<()> {
 }
 
 async fn handle_installation(args: &InstallArgs) -> anyhow::Result<()> {
+    let emit_override = utils::resolve_bool_override(args.emit_hooks, args.no_emit_hooks);
     if let Some(plugins) = &args.plugins {
-        install(plugins, &args.force).await?;
+        install(plugins, &args.force, emit_override).await?;
         info!(
             "\n{}All specified plugins have been installed successfully!",
             Emoji("🎉 ", "")
         );
     } else {
-        install_all(&args.force, &args.prune)?;
+        install_all_with_override(&args.force, &args.prune, emit_override)?;
     }
 
     Ok(())
 }
 
-async fn install(targets: &[InstallTarget], force: &bool) -> anyhow::Result<()> {
+async fn install(
+    targets: &[InstallTarget],
+    force: &bool,
+    emit_override: Option<bool>,
+) -> anyhow::Result<()> {
     let (mut config, config_path) = utils::load_or_create_config()?;
     add_plugins_to_config(&mut config, &config_path, targets)?;
 
@@ -54,7 +59,7 @@ async fn install(targets: &[InstallTarget], force: &bool) -> anyhow::Result<()> 
     let new_plugins = sync_plugin_files(&mut new_plugins, &pez_data_dir).await?;
 
     for plugin in &new_plugins {
-        emit_event(plugin, &utils::Event::Install)?;
+        emit_event(plugin, &utils::Event::Install, emit_override)?;
     }
 
     lock_file.merge_plugins(new_plugins);
@@ -66,13 +71,18 @@ async fn install(targets: &[InstallTarget], force: &bool) -> anyhow::Result<()> 
     Ok(())
 }
 
-fn emit_event(plugin: &Plugin, event: &utils::Event) -> anyhow::Result<()> {
+fn emit_event(
+    plugin: &Plugin,
+    event: &utils::Event,
+    emit_override: Option<bool>,
+) -> anyhow::Result<()> {
+    let hook_override = utils::shell_hooks_override(emit_override, None);
     plugin
         .files
         .iter()
         .filter(|f| f.dir == TargetDir::ConfD)
         .for_each(|f| {
-            let _ = utils::emit_event(&f.name, event);
+            let _ = utils::emit_event_with_override(&f.name, event, hook_override);
         });
 
     Ok(())
@@ -491,11 +501,13 @@ enum InstallOutcome {
     Skipped,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn install_resolved_target(
     plugin_spec: &config::PluginSpec,
     resolved: &ResolvedInstallTarget,
     locked_plugin: Option<&Plugin>,
     force: bool,
+    emit_override: Option<bool>,
     pez_data_dir: &path::Path,
     fish_config_dir: &path::Path,
     dest_paths: &mut HashSet<path::PathBuf>,
@@ -537,11 +549,20 @@ fn install_resolved_target(
         )?;
     }
 
-    emit_event(&plugin, &utils::Event::Install)?;
+    emit_event(&plugin, &utils::Event::Install, emit_override)?;
     Ok(InstallOutcome::Installed(plugin))
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 fn install_all(force: &bool, prune: &bool) -> anyhow::Result<()> {
+    install_all_with_override(force, prune, None)
+}
+
+fn install_all_with_override(
+    force: &bool,
+    prune: &bool,
+    emit_override: Option<bool>,
+) -> anyhow::Result<()> {
     let (mut lock_file, lock_file_path) = utils::load_or_create_lock_file()?;
     let (config, _) = utils::load_config()?;
     let pez_data_dir = utils::load_pez_data_dir()?;
@@ -566,6 +587,7 @@ fn install_all(force: &bool, prune: &bool) -> anyhow::Result<()> {
             &resolved,
             lock_file.get_plugin_by_repo(&repo_for_id),
             *force,
+            emit_override,
             &pez_data_dir,
             &fish_config_dir,
             &mut dest_paths,
@@ -626,7 +648,7 @@ fn install_all(force: &bool, prune: &bool) -> anyhow::Result<()> {
                     Emoji("🗑️  ", ""),
                 );
 
-                emit_event(&plugin, &utils::Event::Uninstall)?;
+                emit_event(&plugin, &utils::Event::Uninstall, emit_override)?;
 
                 let fish_config_dir = utils::load_fish_config_dir()?;
                 for file in &plugin.files {
@@ -843,7 +865,10 @@ mod tests {
     fn test_add_plugin_in_empty_config() {
         let mut test_env = TestEnvironmentSetup::new();
         let _test_data = TestDataBuilder::new().build();
-        test_env.setup_config(config::Config { plugins: None });
+        test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
+            plugins: None,
+        });
 
         let config = test_env.config.as_mut().expect("Config is not initialized");
         let targets = vec![crate::models::InstallTarget::from_raw("owner/new-repo")];
@@ -865,6 +890,7 @@ mod tests {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![test_data.added_plugin_spec.clone()]),
         });
 
@@ -890,6 +916,7 @@ mod tests {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![test_data.added_plugin_spec.clone()]),
         });
 
@@ -980,6 +1007,8 @@ mod tests {
             )]),
             force: false,
             prune: false,
+            emit_hooks: false,
+            no_emit_hooks: false,
         };
 
         tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(run(&args)))
@@ -1038,6 +1067,8 @@ mod tests {
             )]),
             force: false,
             prune: false,
+            emit_hooks: false,
+            no_emit_hooks: false,
         };
 
         let result =
@@ -1305,11 +1336,27 @@ mod tests {
     #[test]
     fn emit_event_only_for_conf_d() {
         let _env_lock = crate::tests_support::log::env_lock().lock().unwrap();
-        let _override = EnvOverride::new(&["PATH", "PEZ_SUPPRESS_EMIT", "PEZ_TEST_FISH_LOG"]);
+        let _override = EnvOverride::new(&[
+            "PATH",
+            "PEZ_SUPPRESS_EMIT",
+            "PEZ_TEST_FISH_LOG",
+            "PEZ_CONFIG_DIR",
+        ]);
         let temp_dir = tempfile::tempdir().unwrap();
         let bin_dir = temp_dir.path().join("bin");
         std::fs::create_dir_all(&bin_dir).unwrap();
         let log_path = temp_dir.path().join("fish.log");
+        let config_dir = temp_dir.path().join("config");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        config::Config {
+            shell_hooks: config::ShellHooksConfig {
+                emit: true,
+                source: false,
+            },
+            plugins: None,
+        }
+        .save(&config_dir.join("pez.toml"))
+        .unwrap();
         let fish_path = bin_dir.join("fish");
         let script = format!("#!/bin/sh\n\necho \"$@\" >> \"{}\"\n", log_path.display());
         std::fs::write(&fish_path, script).unwrap();
@@ -1322,6 +1369,7 @@ mod tests {
             std::env::set_var("PATH", format!("{}:{}", bin_dir.display(), existing_path));
             std::env::remove_var("PEZ_SUPPRESS_EMIT");
             std::env::set_var("PEZ_TEST_FISH_LOG", &log_path);
+            std::env::set_var("PEZ_CONFIG_DIR", &config_dir);
         }
 
         let repo = PluginRepo::new(None, "owner".to_string(), "repo".to_string()).unwrap();
@@ -1342,11 +1390,58 @@ mod tests {
             ],
         };
 
-        emit_event(&plugin, &utils::Event::Install).unwrap();
+        emit_event(&plugin, &utils::Event::Install, None).unwrap();
 
         let log_contents = std::fs::read_to_string(&log_path).unwrap_or_default();
         assert!(log_contents.contains("emit alpha_install"));
         assert!(!log_contents.contains("emit beta_install"));
+    }
+
+    #[test]
+    fn emit_event_is_disabled_by_default() {
+        let _env_lock = crate::tests_support::log::env_lock().lock().unwrap();
+        let _override = EnvOverride::new(&["PATH", "PEZ_SUPPRESS_EMIT", "PEZ_CONFIG_DIR"]);
+        let temp_dir = tempfile::tempdir().unwrap();
+        let bin_dir = temp_dir.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let log_path = temp_dir.path().join("fish.log");
+        let fish_path = bin_dir.join("fish");
+        let script = format!("#!/bin/sh\n\necho \"$@\" >> \"{}\"\n", log_path.display());
+        std::fs::write(&fish_path, script).unwrap();
+        let mut perms = std::fs::metadata(&fish_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fish_path, perms).unwrap();
+
+        let config_dir = temp_dir.path().join("config");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        config::init().save(&config_dir.join("pez.toml")).unwrap();
+
+        let existing_path = std::env::var("PATH").unwrap_or_default();
+        unsafe {
+            std::env::set_var("PATH", format!("{}:{}", bin_dir.display(), existing_path));
+            std::env::remove_var("PEZ_SUPPRESS_EMIT");
+            std::env::set_var("PEZ_CONFIG_DIR", &config_dir);
+        }
+
+        let repo = PluginRepo::new(None, "owner".to_string(), "repo".to_string()).unwrap();
+        let plugin = Plugin {
+            name: "repo".to_string(),
+            repo,
+            source: "source".to_string(),
+            commit_sha: "sha".to_string(),
+            files: vec![PluginFile {
+                dir: TargetDir::ConfD,
+                name: "alpha.fish".to_string(),
+            }],
+        };
+
+        emit_event(&plugin, &utils::Event::Install, None).unwrap();
+
+        let log_contents = std::fs::read_to_string(&log_path).unwrap_or_default();
+        assert!(
+            log_contents.is_empty(),
+            "expected no emit, got: {log_contents}"
+        );
     }
 
     #[test]
@@ -1382,6 +1477,7 @@ mod tests {
         };
         let repo_for_id = plugin_spec.get_plugin_repo().unwrap();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![plugin_spec]),
         });
         test_env.setup_lock_file(crate::lock_file::LockFile {
@@ -1443,6 +1539,7 @@ mod tests {
         let repo_for_id = plugin_spec.get_plugin_repo().unwrap();
         let repo_path = test_env.data_dir.join(repo_for_id.as_str());
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![plugin_spec]),
         });
         test_env.setup_lock_file(crate::lock_file::LockFile {
@@ -1502,6 +1599,7 @@ mod tests {
         };
         let repo_for_id = plugin_spec.get_plugin_repo().unwrap();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![plugin_spec]),
         });
         test_env.setup_lock_file(crate::lock_file::LockFile {
@@ -1564,6 +1662,7 @@ mod tests {
         };
         let repo_for_id = plugin_spec.get_plugin_repo().unwrap();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![plugin_spec]),
         });
         test_env.setup_lock_file(crate::lock_file::LockFile {
@@ -1614,6 +1713,7 @@ mod tests {
         };
         let repo_for_id = plugin_spec.get_plugin_repo().unwrap();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![plugin_spec]),
         });
         test_env.setup_lock_file(crate::lock_file::LockFile {
@@ -1656,6 +1756,7 @@ mod tests {
         let repo_keep = PluginRepo::new(None, "owner".to_string(), "keep".to_string()).unwrap();
         let repo_extra = PluginRepo::new(None, "owner".to_string(), "extra".to_string()).unwrap();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![PluginSpec {
                 name: None,
                 source: PluginSource::Repo {
@@ -1748,6 +1849,7 @@ mod tests {
             },
         };
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![plugin_spec]),
         });
 
@@ -1839,6 +1941,7 @@ mod tests {
             },
         };
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![plugin_spec]),
         });
 

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -508,6 +508,7 @@ mod tests {
         };
         let repo_str = repo.as_str();
         let config = config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![PluginSpec {
                 name: None,
                 source: config::PluginSource::Repo {
@@ -629,6 +630,7 @@ mod tests {
             ],
         });
         env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![PluginSpec {
                 name: None,
                 source: config::PluginSource::Repo {
@@ -832,6 +834,7 @@ mod tests {
         let remote = clone_into_data_dir(&origin_path, &env, &repo);
 
         let config = config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![PluginSpec {
                 name: None,
                 source: config::PluginSource::Repo {
@@ -873,6 +876,7 @@ mod tests {
         let remote = clone_into_data_dir(&origin_path, &env, &repo);
 
         let config = config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![PluginSpec {
                 name: None,
                 source: config::PluginSource::Repo {
@@ -915,6 +919,7 @@ mod tests {
         let remote = clone_into_data_dir(&origin_path, &env, &repo);
 
         let config = config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![PluginSpec {
                 name: None,
                 source: config::PluginSource::Repo {
@@ -959,6 +964,7 @@ mod tests {
         let remote = clone_into_data_dir(&origin_path, &env, &repo);
 
         let config = config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![PluginSpec {
                 name: None,
                 source: config::PluginSource::Repo {
@@ -1007,6 +1013,7 @@ mod tests {
         let remote = clone_into_data_dir(&origin_path, &env, &repo);
 
         let config = config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![PluginSpec {
                 name: None,
                 source: config::PluginSource::Repo {
@@ -1055,6 +1062,7 @@ mod tests {
         let remote = clone_into_data_dir(&origin_path, &env, &repo);
 
         let config = config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![PluginSpec {
                 name: None,
                 source: config::PluginSource::Repo {
@@ -1101,6 +1109,7 @@ mod tests {
         let remote = clone_into_data_dir(&origin_path, &env, &repo);
 
         let config = config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![PluginSpec {
                 name: None,
                 source: config::PluginSource::Repo {

--- a/src/cmd/migrate.rs
+++ b/src/cmd/migrate.rs
@@ -350,6 +350,8 @@ pub(crate) async fn run(args: &MigrateArgs) -> anyhow::Result<()> {
             plugins: Some(targets),
             force: false,
             prune: false,
+            emit_hooks: false,
+            no_emit_hooks: false,
         };
         info!("{}Installing migrated plugins...", Emoji("🚀 ", ""));
         crate::cmd::install::run(&install_args).await?;
@@ -512,6 +514,7 @@ mod tests {
             },
         };
         env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![existing_spec]),
         });
 
@@ -574,6 +577,7 @@ mod tests {
             },
         };
         env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![existing_spec]),
         });
 
@@ -627,6 +631,7 @@ mod tests {
             },
         };
         env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![existing_spec]),
         });
 
@@ -706,7 +711,10 @@ mod tests {
             ("PEZ_CONFIG_DIR", env.config_dir.clone().into_os_string()),
         ]);
 
-        env.setup_config(config::Config { plugins: None });
+        env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
+            plugins: None,
+        });
 
         let fish_plugins_path = env.fish_config_dir.join("fish_plugins");
         fs::write(&fish_plugins_path, "git@bitbucket.org:team/pkg.git\n").unwrap();
@@ -745,7 +753,10 @@ mod tests {
             ("PEZ_CONFIG_DIR", env.config_dir.clone().into_os_string()),
         ]);
 
-        env.setup_config(config::Config { plugins: None });
+        env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
+            plugins: None,
+        });
 
         let fish_plugins_path = env.fish_config_dir.join("fish_plugins");
         fs::write(&fish_plugins_path, "owner/repo@\n").unwrap();
@@ -773,7 +784,10 @@ mod tests {
             ("PEZ_CONFIG_DIR", env.config_dir.clone().into_os_string()),
         ]);
 
-        env.setup_config(config::Config { plugins: None });
+        env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
+            plugins: None,
+        });
 
         let fish_plugins_path = env.fish_config_dir.join("fish_plugins");
         fs::write(
@@ -826,6 +840,7 @@ mod tests {
             },
         };
         env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![existing_spec.clone()]),
         });
 
@@ -874,6 +889,7 @@ mod tests {
             },
         };
         env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![existing_spec.clone()]),
         });
 
@@ -1089,7 +1105,10 @@ mod tests {
         let vars = env_vars(&env);
         let _guard = EnvGuard::set(&vars);
 
-        env.setup_config(config::Config { plugins: None });
+        env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
+            plugins: None,
+        });
         let fish_plugins_path = env.fish_config_dir.join("fish_plugins");
         fs::write(
             &fish_plugins_path,
@@ -1166,6 +1185,7 @@ mod tests {
             },
         };
         env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![existing_spec]),
         });
 
@@ -1207,6 +1227,7 @@ mod tests {
             },
         };
         env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![existing_spec]),
         });
 
@@ -1347,6 +1368,7 @@ mod tests {
             },
         };
         env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![existing_spec]),
         });
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2,6 +2,7 @@ pub mod activate;
 pub mod completion;
 pub mod doctor;
 pub mod files;
+pub mod hook_config;
 pub mod init;
 pub mod install;
 pub mod list;

--- a/src/cmd/prune.rs
+++ b/src/cmd/prune.rs
@@ -572,6 +572,7 @@ mod tests {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![test_data.used_plugin_spec]),
         });
         test_env.setup_lock_file(LockFile {
@@ -611,6 +612,7 @@ mod tests {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![test_data.used_plugin_spec]),
         });
         test_env.setup_lock_file(LockFile {
@@ -650,6 +652,7 @@ mod tests {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![test_data.used_plugin_spec]),
         });
         test_env.setup_lock_file(LockFile {
@@ -680,7 +683,10 @@ mod tests {
     fn test_prune_empty_config_without_yes_and_confirm_removal_true() {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
-        test_env.setup_config(config::Config { plugins: None });
+        test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
+            plugins: None,
+        });
         test_env.setup_lock_file(LockFile {
             version: 1,
             plugins: vec![test_data.unused_plugin],
@@ -704,7 +710,10 @@ mod tests {
     fn test_prune_empty_config_without_yes_and_confirm_removal_false() {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
-        test_env.setup_config(config::Config { plugins: None });
+        test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
+            plugins: None,
+        });
         test_env.setup_lock_file(LockFile {
             version: 1,
             plugins: vec![test_data.unused_plugin],
@@ -733,7 +742,10 @@ mod tests {
     fn test_prune_empty_config_with_yes() {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
-        test_env.setup_config(config::Config { plugins: None });
+        test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
+            plugins: None,
+        });
         test_env.setup_lock_file(LockFile {
             version: 1,
             plugins: vec![test_data.unused_plugin],
@@ -758,6 +770,7 @@ mod tests {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![test_data.used_plugin_spec]),
         });
         test_env.setup_lock_file(LockFile {
@@ -792,6 +805,7 @@ mod tests {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![test_data.used_plugin_spec]),
         });
         test_env.setup_lock_file(LockFile {
@@ -819,6 +833,7 @@ mod tests {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![test_data.used_plugin_spec]),
         });
         test_env.setup_lock_file(LockFile {
@@ -854,6 +869,7 @@ mod tests {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![test_data.used_plugin_spec]),
         });
         test_env.setup_lock_file(LockFile {
@@ -883,7 +899,10 @@ mod tests {
     async fn prune_parallel_aborts_without_yes_when_confirm_false() {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
-        test_env.setup_config(config::Config { plugins: None });
+        test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
+            plugins: None,
+        });
         test_env.setup_lock_file(LockFile {
             version: 1,
             plugins: vec![test_data.unused_plugin],
@@ -899,7 +918,10 @@ mod tests {
         let _jobs = JobsGuard::set(1);
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
-        test_env.setup_config(config::Config { plugins: None });
+        test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
+            plugins: None,
+        });
         test_env.setup_lock_file(LockFile {
             version: 1,
             plugins: vec![test_data.unused_plugin],
@@ -925,6 +947,7 @@ mod tests {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![test_data.used_plugin_spec]),
         });
         test_env.setup_lock_file(LockFile {
@@ -953,6 +976,7 @@ mod tests {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![test_data.used_plugin_spec]),
         });
         test_env.setup_lock_file(LockFile {
@@ -988,6 +1012,7 @@ mod tests {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![test_data.used_plugin_spec]),
         });
         test_env.setup_lock_file(LockFile {
@@ -1028,6 +1053,7 @@ mod tests {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![test_data.used_plugin_spec]),
         });
         test_env.setup_lock_file(LockFile {
@@ -1050,6 +1076,7 @@ mod tests {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
         test_env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![test_data.used_plugin_spec]),
         });
         test_env.setup_lock_file(LockFile {

--- a/src/cmd/uninstall.rs
+++ b/src/cmd/uninstall.rs
@@ -7,6 +7,7 @@ use tracing::{error, info, warn};
 
 pub(crate) async fn run(args: &UninstallArgs) -> anyhow::Result<()> {
     info!("{}Starting uninstallation process...", Emoji("🔍 ", ""));
+    let emit_override = utils::resolve_bool_override(args.emit_hooks, args.no_emit_hooks);
     let jobs = utils::load_jobs().max(1);
     let mut plugins: Vec<PluginRepo> = args.plugins.clone().unwrap_or_default();
     if plugins.is_empty() && args.stdin {
@@ -23,7 +24,7 @@ pub(crate) async fn run(args: &UninstallArgs) -> anyhow::Result<()> {
             let force = args.force;
             tokio::task::spawn_blocking(move || {
                 info!("\n{}Uninstalling plugin: {}", Emoji("✨ ", ""), plugin);
-                uninstall(&plugin, force)
+                uninstall_with_override(&plugin, force, emit_override)
             })
         })
         .buffer_unordered(jobs);
@@ -77,7 +78,16 @@ fn read_plugins_from_stdin() -> anyhow::Result<Vec<PluginRepo>> {
     read_plugins_from_reader(handle)
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn uninstall(plugin_repo: &PluginRepo, force: bool) -> anyhow::Result<()> {
+    uninstall_with_override(plugin_repo, force, None)
+}
+
+fn uninstall_with_override(
+    plugin_repo: &PluginRepo,
+    force: bool,
+    emit_override: Option<bool>,
+) -> anyhow::Result<()> {
     let plugin_repo_str = plugin_repo.as_str();
     let config_dir = utils::load_fish_config_dir()?;
 
@@ -92,7 +102,11 @@ pub(crate) fn uninstall(plugin_repo: &PluginRepo, force: bool) -> anyhow::Result
                 .iter()
                 .filter(|f| f.dir == TargetDir::ConfD)
                 .for_each(|f| {
-                    let _ = utils::emit_event(&f.name, &utils::Event::Uninstall);
+                    let _ = utils::emit_event_with_override(
+                        &f.name,
+                        &utils::Event::Uninstall,
+                        utils::shell_hooks_override(emit_override, None),
+                    );
                 });
 
             if repo_path.exists() {
@@ -312,6 +326,10 @@ owner/plugin-a
             },
         };
         env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig {
+                emit: true,
+                source: false,
+            },
             plugins: Some(vec![spec]),
         });
 
@@ -414,6 +432,10 @@ owner/plugin-a
             },
         };
         env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig {
+                emit: true,
+                source: false,
+            },
             plugins: Some(vec![spec]),
         });
         env.setup_data_repo(vec![repo.clone()]);
@@ -488,6 +510,7 @@ owner/plugin-a
             repo: "missing".into(),
         };
         env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![config::PluginSpec {
                 name: None,
                 source: config::PluginSource::Repo {
@@ -595,6 +618,10 @@ owner/plugin-a
             },
         };
         env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig {
+                emit: true,
+                source: false,
+            },
             plugins: Some(vec![spec]),
         });
         env.setup_data_repo(vec![repo.clone()]);
@@ -633,6 +660,88 @@ owner/plugin-a
         assert!(!log_contents.contains("emit beta_uninstall"));
     }
 
+    #[test]
+    fn uninstall_does_not_emit_by_default() {
+        let _lock = crate::tests_support::log::env_lock().lock().unwrap();
+        let mut env = TestEnvironmentSetup::new();
+        let _override = EnvOverride::new(&[
+            "PATH",
+            "PEZ_SUPPRESS_EMIT",
+            "__fish_config_dir",
+            "PEZ_CONFIG_DIR",
+            "PEZ_DATA_DIR",
+        ]);
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let bin_dir = temp_dir.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let log_path = temp_dir.path().join("fish.log");
+        let fish_path = bin_dir.join("fish");
+        let script = format!("#!/bin/sh\n\necho \"$@\" >> \"{}\"\n", log_path.display());
+        std::fs::write(&fish_path, script).unwrap();
+        let mut perms = std::fs::metadata(&fish_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fish_path, perms).unwrap();
+
+        let existing_path = std::env::var("PATH").unwrap_or_default();
+        unsafe {
+            std::env::set_var("PATH", format!("{}:{}", bin_dir.display(), existing_path));
+            std::env::remove_var("PEZ_SUPPRESS_EMIT");
+            std::env::set_var("__fish_config_dir", &env.fish_config_dir);
+            std::env::set_var("PEZ_CONFIG_DIR", &env.config_dir);
+            std::env::set_var("PEZ_DATA_DIR", &env.data_dir);
+        }
+
+        let repo = PluginRepo {
+            host: None,
+            owner: "owner".into(),
+            repo: "emit".into(),
+        };
+        let spec = config::PluginSpec {
+            name: None,
+            source: config::PluginSource::Repo {
+                repo: repo.clone(),
+                version: None,
+                branch: None,
+                tag: None,
+                commit: None,
+            },
+        };
+        env.setup_config(config::init());
+        if let Some(config) = env.config.clone() {
+            let mut updated = config;
+            updated.plugins = Some(vec![spec]);
+            env.setup_config(updated);
+        }
+        env.setup_data_repo(vec![repo.clone()]);
+
+        let conf_dir = env.fish_config_dir.join(TargetDir::ConfD.as_str());
+        std::fs::create_dir_all(&conf_dir).unwrap();
+        std::fs::File::create(conf_dir.join("alpha.fish")).unwrap();
+
+        env.setup_lock_file(LockFile {
+            version: 1,
+            plugins: vec![crate::lock_file::Plugin {
+                name: "emit".into(),
+                repo: repo.clone(),
+                source: repo.default_remote_source(),
+                commit_sha: "abc1234".into(),
+                files: vec![PluginFile {
+                    dir: TargetDir::ConfD,
+                    name: "alpha.fish".into(),
+                }],
+            }],
+        });
+
+        uninstall(&repo, true).expect("uninstall should succeed");
+
+        let log_contents = std::fs::read_to_string(&log_path).unwrap_or_default();
+        assert!(
+            log_contents.is_empty(),
+            "expected no emit, got: {log_contents}"
+        );
+    }
+
     #[allow(clippy::await_holding_lock)]
     #[tokio::test(flavor = "multi_thread")]
     async fn run_bails_without_plugins_or_stdin() {
@@ -643,6 +752,8 @@ owner/plugin-a
             plugins: None,
             force: false,
             stdin: false,
+            emit_hooks: false,
+            no_emit_hooks: false,
         };
         let err = run(&args).await.expect_err("expected failure");
         assert!(
@@ -686,6 +797,7 @@ owner/plugin-a
             },
         };
         env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![spec]),
         });
         env.setup_data_repo(vec![repo.clone()]);
@@ -714,6 +826,8 @@ owner/plugin-a
             plugins: None,
             force: true,
             stdin: true,
+            emit_hooks: false,
+            no_emit_hooks: false,
         };
         run(&args).await.expect("run should succeed");
 
@@ -757,6 +871,7 @@ owner/plugin-a
             },
         };
         env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![spec]),
         });
         env.setup_data_repo(vec![repo.clone()]);
@@ -784,6 +899,8 @@ owner/plugin-a
             plugins: Some(vec![repo.clone()]),
             force: true,
             stdin: false,
+            emit_hooks: false,
+            no_emit_hooks: false,
         };
         run(&args).await.expect("run should succeed");
 

--- a/src/cmd/upgrade.rs
+++ b/src/cmd/upgrade.rs
@@ -13,6 +13,7 @@ use tracing::{error, info, warn};
 
 pub(crate) async fn run(args: &UpgradeArgs) -> anyhow::Result<()> {
     info!("{}Starting upgrade process...", Emoji("🔍 ", ""));
+    let emit_override = utils::resolve_bool_override(args.emit_hooks, args.no_emit_hooks);
     if let Some(plugins) = &args.plugins {
         let jobs = utils::load_jobs().max(1);
         let tasks = stream::iter(plugins.iter())
@@ -20,7 +21,7 @@ pub(crate) async fn run(args: &UpgradeArgs) -> anyhow::Result<()> {
                 let plugin = plugin.clone();
                 tokio::task::spawn_blocking(move || {
                     info!("{}Upgrading plugin: {}", Emoji("✨ ", ""), &plugin);
-                    let res = upgrade(&plugin);
+                    let res = upgrade(&plugin, emit_override);
                     if res.is_ok() {
                         info!(
                             "{}Successfully upgraded plugin: {}",
@@ -37,7 +38,7 @@ pub(crate) async fn run(args: &UpgradeArgs) -> anyhow::Result<()> {
             r??;
         }
     } else {
-        upgrade_all().await?;
+        upgrade_all(emit_override).await?;
     }
     info!(
         "{}All specified plugins have been upgraded successfully!",
@@ -47,19 +48,19 @@ pub(crate) async fn run(args: &UpgradeArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn upgrade(plugin: &PluginRepo) -> anyhow::Result<()> {
+fn upgrade(plugin: &PluginRepo, emit_override: Option<bool>) -> anyhow::Result<()> {
     let (mut config, config_path) = utils::load_or_create_config()?;
 
     if config.ensure_plugin_for_repo(plugin) {
         config.save(&config_path)?;
     }
 
-    upgrade_plugin(plugin)?;
+    upgrade_plugin_with_override(plugin, emit_override)?;
 
     Ok(())
 }
 
-async fn upgrade_all() -> anyhow::Result<()> {
+async fn upgrade_all_with_override(emit_override: Option<bool>) -> anyhow::Result<()> {
     let (config, _) = utils::load_or_create_config()?;
     if let Some(plugins) = &config.plugins {
         let repos: Vec<PluginRepo> = plugins
@@ -71,7 +72,7 @@ async fn upgrade_all() -> anyhow::Result<()> {
             .map(|repo| {
                 tokio::task::spawn_blocking(move || {
                     info!("{}Upgrading plugin: {}", Emoji("✨ ", ""), &repo);
-                    upgrade_plugin(&repo)
+                    upgrade_plugin_with_override(&repo, emit_override)
                 })
             })
             .buffer_unordered(jobs);
@@ -84,7 +85,19 @@ async fn upgrade_all() -> anyhow::Result<()> {
     Ok(())
 }
 
+async fn upgrade_all(emit_override: Option<bool>) -> anyhow::Result<()> {
+    upgrade_all_with_override(emit_override).await
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
 fn upgrade_plugin(plugin_repo: &PluginRepo) -> anyhow::Result<()> {
+    upgrade_plugin_with_override(plugin_repo, None)
+}
+
+fn upgrade_plugin_with_override(
+    plugin_repo: &PluginRepo,
+    emit_override: Option<bool>,
+) -> anyhow::Result<()> {
     let (mut lock_file, lock_file_path) = utils::load_or_create_lock_file()?;
     let (config, _) = utils::load_or_create_config()?;
     let config_dir = utils::load_fish_config_dir()?;
@@ -161,7 +174,11 @@ fn upgrade_plugin(plugin_repo: &PluginRepo) -> anyhow::Result<()> {
                     .iter()
                     .filter(|f| f.dir == TargetDir::ConfD)
                     .for_each(|f| {
-                        if let Err(e) = utils::emit_event(&f.name, &utils::Event::Update) {
+                        if let Err(e) = utils::emit_event_with_override(
+                            &f.name,
+                            &utils::Event::Update,
+                            utils::shell_hooks_override(emit_override, None),
+                        ) {
                             error!("Failed to emit event for {}: {:?}", &f.name, e);
                         }
                     });
@@ -381,6 +398,7 @@ mod tests {
 
             let config = if include_in_config {
                 config::Config {
+                    shell_hooks: config::ShellHooksConfig::default(),
                     plugins: Some(vec![config::PluginSpec {
                         name: None,
                         source: config::PluginSource::Repo {
@@ -393,7 +411,10 @@ mod tests {
                     }]),
                 }
             } else {
-                config::Config { plugins: None }
+                config::Config {
+                    shell_hooks: config::ShellHooksConfig::default(),
+                    plugins: None,
+                }
             };
             env.setup_config(config);
 
@@ -497,6 +518,7 @@ mod tests {
             }],
         });
         env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![config::PluginSpec {
                 name: None,
                 source: config::PluginSource::Repo {
@@ -560,6 +582,7 @@ mod tests {
         }
 
         fixture.env.setup_config(config::Config {
+            shell_hooks: config::ShellHooksConfig::default(),
             plugins: Some(vec![config::PluginSpec {
                 name: None,
                 source: config::PluginSource::Repo {
@@ -659,6 +682,8 @@ mod tests {
 
         let args = UpgradeArgs {
             plugins: Some(vec![fixture.repo.clone()]),
+            emit_hooks: true,
+            no_emit_hooks: false,
         };
         run(&args).await.expect("run should succeed");
 
@@ -677,6 +702,56 @@ mod tests {
         let log_contents = std::fs::read_to_string(&log_path).unwrap_or_default();
         assert!(log_contents.contains("emit alpha_update"));
         assert!(!log_contents.contains("emit beta_update"));
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_upgrades_selected_plugins_do_not_emit_by_default() {
+        let _lock = crate::tests_support::log::env_lock().lock().unwrap();
+        crate::utils::clear_cli_jobs_override_for_tests();
+        let fixture = UpgradeFixture::new(false);
+        let _override = EnvOverride::new(&[
+            "PATH",
+            "PEZ_SUPPRESS_EMIT",
+            "__fish_config_dir",
+            "PEZ_CONFIG_DIR",
+            "PEZ_DATA_DIR",
+            "PEZ_JOBS",
+        ]);
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let bin_dir = temp_dir.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let log_path = temp_dir.path().join("fish.log");
+        let fish_path = bin_dir.join("fish");
+        let script = format!("#!/bin/sh\n\necho \"$@\" >> \"{}\"\n", log_path.display());
+        std::fs::write(&fish_path, script).unwrap();
+        let mut perms = std::fs::metadata(&fish_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fish_path, perms).unwrap();
+
+        let existing_path = std::env::var("PATH").unwrap_or_default();
+        unsafe {
+            std::env::set_var("PATH", format!("{}:{}", bin_dir.display(), existing_path));
+            std::env::remove_var("PEZ_SUPPRESS_EMIT");
+            std::env::set_var("__fish_config_dir", &fixture.env.fish_config_dir);
+            std::env::set_var("PEZ_CONFIG_DIR", &fixture.env.config_dir);
+            std::env::set_var("PEZ_DATA_DIR", &fixture.env.data_dir);
+            std::env::set_var("PEZ_JOBS", "1");
+        }
+
+        let args = UpgradeArgs {
+            plugins: Some(vec![fixture.repo.clone()]),
+            emit_hooks: false,
+            no_emit_hooks: false,
+        };
+        run(&args).await.expect("run should succeed");
+
+        let log_contents = std::fs::read_to_string(&log_path).unwrap_or_default();
+        assert!(
+            log_contents.is_empty(),
+            "expected no emit, got: {log_contents}"
+        );
     }
 
     #[allow(clippy::await_holding_lock)]
@@ -700,7 +775,11 @@ mod tests {
             std::env::set_var("PEZ_JOBS", "1");
         }
 
-        let args = UpgradeArgs { plugins: None };
+        let args = UpgradeArgs {
+            plugins: None,
+            emit_hooks: false,
+            no_emit_hooks: false,
+        };
         run(&args).await.expect("run should succeed");
 
         let lock = lock_file::load(&fixture.env.lock_file_path).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,17 @@ use crate::resolver::{ref_kind_to_repo_source, ref_kind_to_url_source};
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
+    #[serde(default)]
+    pub(crate) shell_hooks: ShellHooksConfig,
     pub(crate) plugins: Option<Vec<PluginSpec>>,
+}
+
+#[cfg_attr(feature = "schema-gen", derive(schemars::JsonSchema))]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub(crate) struct ShellHooksConfig {
+    pub(crate) emit: bool,
+    pub(crate) source: bool,
 }
 
 #[cfg_attr(feature = "schema-gen", derive(schemars::JsonSchema))]
@@ -56,7 +66,10 @@ pub(crate) enum PluginSource {
 }
 
 pub(crate) fn init() -> Config {
-    Config { plugins: None }
+    Config {
+        shell_hooks: ShellHooksConfig::default(),
+        plugins: None,
+    }
 }
 
 pub(crate) fn load(path: &path::PathBuf) -> anyhow::Result<Config> {
@@ -446,7 +459,10 @@ mod internal_tests {
 
     #[test]
     fn ensure_plugin_from_resolved_inserts_once() {
-        let mut config = Config { plugins: None };
+        let mut config = Config {
+            shell_hooks: ShellHooksConfig::default(),
+            plugins: None,
+        };
         let resolved = ResolvedInstallTarget {
             plugin_repo: PluginRepo {
                 host: None,
@@ -466,7 +482,10 @@ mod internal_tests {
 
     #[test]
     fn ensure_plugin_for_repo_inserts_default_spec() {
-        let mut config = Config { plugins: None };
+        let mut config = Config {
+            shell_hooks: ShellHooksConfig::default(),
+            plugins: None,
+        };
         let repo = PluginRepo {
             host: None,
             owner: "o".into(),
@@ -751,6 +770,7 @@ branch = "main"
     #[test]
     fn config_validate_rejects_relative_path() {
         let config = Config {
+            shell_hooks: ShellHooksConfig::default(),
             plugins: Some(vec![PluginSpec {
                 name: None,
                 source: PluginSource::Path {
@@ -764,5 +784,24 @@ branch = "main"
             msg.contains("invalid plugins[0]") || msg.contains("path must be absolute"),
             "{msg}"
         );
+    }
+
+    #[test]
+    fn init_disables_shell_hooks_by_default() {
+        let config = init();
+        assert!(!config.shell_hooks.emit);
+        assert!(!config.shell_hooks.source);
+    }
+
+    #[test]
+    fn parse_config_accepts_shell_hooks() {
+        let content = r#"
+[shell_hooks]
+emit = true
+source = true
+"#;
+        let config = parse_config(content).unwrap();
+        assert!(config.shell_hooks.emit);
+        assert!(config.shell_hooks.source);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,9 @@ pub async fn run() -> anyhow::Result<()> {
         cli::Commands::Doctor(args) => {
             let _ = cmd::doctor::run(args)?;
         }
+        cli::Commands::HookConfig(args) => {
+            let _ = cmd::hook_config::run(args)?;
+        }
         cli::Commands::Migrate(args) => {
             cmd::migrate::run(args).await?;
         }
@@ -75,7 +78,7 @@ pub async fn run() -> anyhow::Result<()> {
         }
         cli::Commands::Activate(args) => match args.shell {
             cli::ShellType::Fish => {
-                let _ = cmd::activate::run_fish();
+                let _ = cmd::activate::run_fish(args);
             }
         },
         cli::Commands::Completions { shell } => match shell {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -106,6 +106,44 @@ pub(crate) fn clear_cli_jobs_override_for_tests() {
     *cli_jobs_override().lock().unwrap() = None;
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ShellHooksOverride {
+    pub emit: Option<bool>,
+    pub source: Option<bool>,
+}
+
+pub(crate) fn resolve_bool_override(enabled: bool, disabled: bool) -> Option<bool> {
+    match (enabled, disabled) {
+        (true, false) => Some(true),
+        (false, true) => Some(false),
+        _ => None,
+    }
+}
+
+pub(crate) fn shell_hooks_override(emit: Option<bool>, source: Option<bool>) -> ShellHooksOverride {
+    ShellHooksOverride { emit, source }
+}
+
+pub(crate) fn load_shell_hooks_config() -> anyhow::Result<config::ShellHooksConfig> {
+    match load_config() {
+        Ok((config, _)) => Ok(config.shell_hooks),
+        Err(_) => Ok(config::init().shell_hooks),
+    }
+}
+
+pub(crate) fn resolve_shell_hooks_with_override(
+    override_value: ShellHooksOverride,
+) -> anyhow::Result<config::ShellHooksConfig> {
+    let mut shell_hooks = load_shell_hooks_config()?;
+    if let Some(value) = override_value.emit {
+        shell_hooks.emit = value;
+    }
+    if let Some(value) = override_value.source {
+        shell_hooks.source = value;
+    }
+    Ok(shell_hooks)
+}
+
 pub(crate) fn load_config() -> anyhow::Result<(config::Config, path::PathBuf)> {
     let config_path = load_pez_config_dir()?.join("pez.toml");
 
@@ -333,10 +371,21 @@ impl fmt::Display for Event {
     }
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn emit_event(file_name_or_path: &str, event: &Event) -> anyhow::Result<()> {
-    // Allow callers (e.g., fish wrapper) to suppress out-of-process emits to
-    // avoid duplicate hooks when the shell itself handles events in-process.
-    if std::env::var_os("PEZ_SUPPRESS_EMIT").is_some() {
+    emit_event_with_override(file_name_or_path, event, ShellHooksOverride::default())
+}
+
+pub(crate) fn emit_event_with_override(
+    file_name_or_path: &str,
+    event: &Event,
+    override_value: ShellHooksOverride,
+) -> anyhow::Result<()> {
+    let mut shell_hooks = resolve_shell_hooks_with_override(override_value)?;
+    if env::var_os("PEZ_SUPPRESS_EMIT").is_some() {
+        shell_hooks.emit = false;
+    }
+    if !shell_hooks.emit {
         return Ok(());
     }
 
@@ -1215,9 +1264,22 @@ mod tests {
     #[test]
     fn emit_event_warns_when_stem_missing() {
         let _lock = env_lock().lock().unwrap();
-        let _guard = EnvGuard::capture(&["PEZ_SUPPRESS_EMIT"]);
+        let _guard = EnvGuard::capture(&["PEZ_SUPPRESS_EMIT", "PEZ_CONFIG_DIR"]);
+        let temp = tempfile::tempdir().unwrap();
+        let config_dir = temp.path().join("config");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        config::Config {
+            shell_hooks: config::ShellHooksConfig {
+                emit: true,
+                source: false,
+            },
+            plugins: None,
+        }
+        .save(&config_dir.join("pez.toml"))
+        .unwrap();
         unsafe {
             std::env::remove_var("PEZ_SUPPRESS_EMIT");
+            std::env::set_var("PEZ_CONFIG_DIR", &config_dir);
         }
 
         let (logs, result) = capture_logs(|| emit_event("", &Event::Install));
@@ -1298,9 +1360,20 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         let _lock = env_lock().lock().unwrap();
-        let _guard = EnvGuard::capture(&["PEZ_SUPPRESS_EMIT", "PATH"]);
+        let _guard = EnvGuard::capture(&["PEZ_SUPPRESS_EMIT", "PATH", "PEZ_CONFIG_DIR"]);
 
         let temp = tempfile::tempdir().unwrap();
+        let config_dir = temp.path().join("config");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        config::Config {
+            shell_hooks: config::ShellHooksConfig {
+                emit: true,
+                source: false,
+            },
+            plugins: None,
+        }
+        .save(&config_dir.join("pez.toml"))
+        .unwrap();
         let fish_path = temp.path().join("fish");
         std::fs::write(&fish_path, "#!/bin/sh\nexit 1\n").unwrap();
         let mut perms = std::fs::metadata(&fish_path).unwrap().permissions();
@@ -1313,6 +1386,7 @@ mod tests {
         unsafe {
             std::env::remove_var("PEZ_SUPPRESS_EMIT");
             std::env::set_var("PATH", new_path);
+            std::env::set_var("PEZ_CONFIG_DIR", &config_dir);
         }
 
         let (logs, result) = capture_logs(|| emit_event("plugin.fish", &Event::Install));


### PR DESCRIPTION
This pull request introduces a comprehensive and configurable shell hook system for pez, allowing users to control how and when Fish shell `conf.d` hooks are emitted or sourced. It adds new configuration options, updates documentation, and enhances CLI commands to support runtime and per-command overrides for hook behavior. The changes make hook execution explicit, safer by default, and much more flexible, especially for users migrating from `fisher`.

**Shell hook configuration and behavior:**

* Adds a `[shell_hooks]` section to `pez.toml` (and schema) with `emit` and `source` booleans (both default to `false`), letting users control if and how `conf.d` hooks are executed. The activation wrapper now reads this config at runtime, so changes take effect immediately without regenerating the wrapper. [[1]](diffhunk://#diff-be1695b1e63a508d59982601f9e1fb7f58247deecb1e427adb77bcad758ae5e5R4-R19) [[2]](diffhunk://#diff-be1695b1e63a508d59982601f9e1fb7f58247deecb1e427adb77bcad758ae5e5R159-R169) [[3]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R115-R151) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R99) [[6]](diffhunk://#diff-57cdcc6b6701a7ce3b3a8f8c0366e0e611e6fb1a1b8dd7cd29e3263b3e064c8bL29-R56) [[7]](diffhunk://#diff-620acce917cb73971b261a606241382bdaddd71446257a17837c1f9b44f264c9L7-R60)

* Updates the activation wrapper (`pez activate fish`) to use the new runtime-configured shell hook logic, and documents the new behavior and config in the README and migration guide. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R67) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L166-R183) [[3]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L16-R17) [[4]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L27-R28)

**CLI and command enhancements:**

* Adds new CLI flags (`--emit-hooks`, `--no-emit-hooks`, `--source-hooks`, `--no-source-hooks`) to `install`, `upgrade`, `uninstall`, and `activate` commands, allowing per-command override of hook behavior. [[1]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR85-R92) [[2]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR107-R128) [[3]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR236-R251) [[4]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR48) [[5]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR67) [[6]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR78) [[7]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R115-R151)

* Introduces a new `hook-config` command to display the effective shell hook configuration, supporting CLI overrides and subcommand context. [[1]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR60-R62) [[2]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR16) [[3]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eL111-R138)

**Documentation and migration improvements:**

* Thoroughly updates documentation (`README.md`, `docs/commands.md`, `docs/configuration.md`, `docs/faq.md`, `docs/migrate-from-fisher.md`, `docs/architecture.md`) to explain the new shell hook system, its defaults, migration steps, and security implications. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L118-R130) [[2]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR104-R106) [[3]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR163) [[4]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L16-R17) [[5]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L27-R28) [[6]](diffhunk://#diff-620acce917cb73971b261a606241382bdaddd71446257a17837c1f9b44f264c9L7-R60) [[7]](diffhunk://#diff-57cdcc6b6701a7ce3b3a8f8c0366e0e611e6fb1a1b8dd7cd29e3263b3e064c8bL29-R56)

* Clarifies that copying `conf.d` files is always performed, but emitting or sourcing hooks is only done if enabled via config or CLI override. [[1]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R115-R151) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L166-R183)

These changes make pez's hook behavior explicit, opt-in, and highly configurable, providing a safer default for new users and a familiar experience for those migrating from fisher.