### PR TITLE
fix(upgrade): remove redundant into_iter in upgrade_all

### DIFF
--- a/src/cmd/upgrade.rs
+++ b/src/cmd/upgrade.rs
@@ -67,7 +67,7 @@ async fn upgrade_all() -> anyhow::Result<()> {
             .filter_map(|p| p.get_plugin_repo().ok())
             .collect();
         let jobs = utils::load_jobs().max(1);
-        let tasks = stream::iter(repos.into_iter())
+        let tasks = stream::iter(repos)
             .map(|repo| {
                 tokio::task::spawn_blocking(move || {
                     info!("{}Upgrading plugin: {}", Emoji("✨ ", ""), &repo);


### PR DESCRIPTION
This pull request makes a minor code simplification in the `upgrade_all` function by removing an unnecessary call to `.into_iter()` when creating a stream from the `repos` collection. This change helps streamline the code without affecting its behavior.