### PR TITLE
fix: avoid shell interpolation for fish event emits

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ This document outlines the high‑level structure and flows in pez.
 4. Resolve the commit using `resolver::RefKind` -> `git::resolve_selection`.
 5. Copy files to the Fish config directory using `utils::copy_plugin_files*`.
 6. Update the lockfile with `name`/`repo`/`source`/`commit_sha`/`files`.
-7. For files under `conf.d`, emit `fish -c 'emit <stem>_{install|update|uninstall}'` events.
+7. For files under `conf.d` with safe stems, emit `<stem>_{install|update|uninstall}` fish events.
 
 ## Concurrency
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -109,6 +109,7 @@ Global options (apply to all commands)
 - Output shell activation code that wraps `pez` with hooks in the current shell.
 - Usage: `pez activate fish | source` (for persistence, add inside `if status is-interactive ... end` in `~/.config/fish/config.fish`).
 - Behavior: after `install`/`upgrade`, sources matching `conf.d` files and emits `<stem>_{install|update}` in the current shell; before `uninstall`, emits `<stem>_uninstall`.
+- Out-of-process event emits only run for safe stems (`A-Z`, `a-z`, `0-9`, `_`, `-`, or `.`).
 - When active, the wrapper runs `pez` with `PEZ_SUPPRESS_EMIT=1` to avoid duplicate out-of-process emits.
 
 ### files

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,14 +118,14 @@ Notes
 - It copies files recursively into the matching Fish config directories, preserving relative paths.
 - Only `.fish` files are copied from `functions`/`completions`/`conf.d`, and only `.theme` files from `themes`.
 - If two plugins would write the same destination path in a single run, the later plugin is skipped and its files are not recorded in the lockfile.
-- For `conf.d` files, pez emits `emit <stem>_{install|update|uninstall}` after installs/upgrades or before uninstalls (unless `PEZ_SUPPRESS_EMIT` is set).
+- For `conf.d` files with safe stems (`A-Z`, `a-z`, `0-9`, `_`, `-`, or `.`), pez emits `<stem>_{install|update|uninstall}` after installs/upgrades or before uninstalls (unless `PEZ_SUPPRESS_EMIT` is set).
 
 ## Environment Variables and CLI Overrides
 
 - `PEZ_CONFIG_DIR` — Directory containing `pez.toml` and `pez-lock.toml`.
 - `PEZ_DATA_DIR` — Base directory for cloned plugin repositories.
 - `PEZ_TARGET_DIR` — Override the Fish config directory used for copying plugin files. It no longer changes where `pez.toml` or `pez-lock.toml` live.
-- `PEZ_SUPPRESS_EMIT` — When set, suppress `fish -c 'emit ...'` hooks during install/upgrade/uninstall. Used by `pez activate fish` to avoid duplicate events.
+- `PEZ_SUPPRESS_EMIT` — When set, suppress out-of-process fish event hooks during install/upgrade/uninstall. Used by `pez activate fish` to avoid duplicate events.
 - `__fish_config_dir` / `XDG_CONFIG_HOME` — Fish configuration directory.
 - `__fish_user_data_dir` / `XDG_DATA_HOME` — Fish data directory.
 - `--jobs <N>` — Global CLI flag to override concurrency for `install` (explicit

--- a/src/cmd/install.rs
+++ b/src/cmd/install.rs
@@ -1345,8 +1345,8 @@ mod tests {
         emit_event(&plugin, &utils::Event::Install).unwrap();
 
         let log_contents = std::fs::read_to_string(&log_path).unwrap_or_default();
-        assert!(log_contents.contains("emit alpha_install"));
-        assert!(!log_contents.contains("emit beta_install"));
+        assert!(log_contents.contains("alpha_install"));
+        assert!(!log_contents.contains("beta_install"));
     }
 
     #[test]

--- a/src/cmd/uninstall.rs
+++ b/src/cmd/uninstall.rs
@@ -629,8 +629,8 @@ owner/plugin-a
         uninstall(&repo, true).expect("uninstall should succeed");
 
         let log_contents = std::fs::read_to_string(&log_path).unwrap_or_default();
-        assert!(log_contents.contains("emit alpha_uninstall"));
-        assert!(!log_contents.contains("emit beta_uninstall"));
+        assert!(log_contents.contains("alpha_uninstall"));
+        assert!(!log_contents.contains("beta_uninstall"));
     }
 
     #[allow(clippy::await_holding_lock)]

--- a/src/cmd/upgrade.rs
+++ b/src/cmd/upgrade.rs
@@ -675,8 +675,8 @@ mod tests {
         assert_eq!(updated.commit_sha, fixture.second_commit);
 
         let log_contents = std::fs::read_to_string(&log_path).unwrap_or_default();
-        assert!(log_contents.contains("emit alpha_update"));
-        assert!(!log_contents.contains("emit beta_update"));
+        assert!(log_contents.contains("alpha_update"));
+        assert!(!log_contents.contains("beta_update"));
     }
 
     #[allow(clippy::await_holding_lock)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -345,13 +345,20 @@ pub(crate) fn emit_event(file_name_or_path: &str, event: &Event) -> anyhow::Resu
         .and_then(|s| s.to_str());
     match stem_opt {
         Some(stem) => {
+            if !is_safe_event_stem(stem) {
+                warn!("Skipping unsafe event name stem: {:?}", stem);
+                return Ok(());
+            }
+            let event_name = format!("{stem}_{event}");
             let output = std::process::Command::new("fish")
                 .arg("-c")
-                .arg(format!("emit {stem}_{event}"))
+                .arg(r#"emit -- "$argv[1]""#)
+                .arg("--")
+                .arg(&event_name)
                 .spawn()
                 .context("Failed to spawn fish to emit event")?
                 .wait_with_output()?;
-            debug!("Emitted event: {}_{}", stem, event);
+            debug!("Emitted event: {}", event_name);
 
             if !output.status.success() {
                 error!("Command executed with failing error code");
@@ -366,6 +373,13 @@ pub(crate) fn emit_event(file_name_or_path: &str, event: &Event) -> anyhow::Resu
     }
 
     Ok(())
+}
+
+fn is_safe_event_stem(stem: &str) -> bool {
+    !stem.is_empty()
+        && stem
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
 }
 
 fn warn_no_plugin_files() {
@@ -1225,6 +1239,82 @@ mod tests {
         assert!(
             logs.iter()
                 .any(|msg| msg.contains("Could not extract plugin name"))
+        );
+    }
+
+    #[cfg(unix)]
+    fn install_fake_fish(temp: &tempfile::TempDir, script: &str) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+
+        let fish_path = temp.path().join("fish");
+        std::fs::write(&fish_path, script).unwrap();
+        let mut perms = std::fs::metadata(&fish_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fish_path, perms).unwrap();
+        fish_path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn emit_event_passes_event_name_as_fish_argv() {
+        let _lock = env_lock().lock().unwrap();
+        let _guard = EnvGuard::capture(&["PEZ_SUPPRESS_EMIT", "PATH"]);
+
+        let temp = tempfile::tempdir().unwrap();
+        let log_path = temp.path().join("fish-args.log");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"{}\"\n",
+            log_path.display()
+        );
+        install_fake_fish(&temp, &script);
+
+        let old_path = std::env::var_os("PATH").unwrap_or_default();
+        let new_path = format!("{}:{}", temp.path().display(), old_path.to_string_lossy());
+
+        unsafe {
+            std::env::remove_var("PEZ_SUPPRESS_EMIT");
+            std::env::set_var("PATH", new_path);
+        }
+
+        emit_event("safe-plugin.fish", &Event::Install).unwrap();
+
+        let args = std::fs::read_to_string(log_path).unwrap();
+        let args: Vec<&str> = args.lines().collect();
+        assert_eq!(
+            args,
+            vec!["-c", r#"emit -- "$argv[1]""#, "--", "safe-plugin_install"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn emit_event_skips_unsafe_stem_without_spawning_fish() {
+        let _lock = env_lock().lock().unwrap();
+        let _guard = EnvGuard::capture(&["PEZ_SUPPRESS_EMIT", "PATH"]);
+
+        let temp = tempfile::tempdir().unwrap();
+        let log_path = temp.path().join("fish-invoked.log");
+        let script = format!(
+            "#!/bin/sh\necho invoked > \"{}\"\nexit 7\n",
+            log_path.display()
+        );
+        install_fake_fish(&temp, &script);
+
+        let old_path = std::env::var_os("PATH").unwrap_or_default();
+        let new_path = format!("{}:{}", temp.path().display(), old_path.to_string_lossy());
+
+        unsafe {
+            std::env::remove_var("PEZ_SUPPRESS_EMIT");
+            std::env::set_var("PATH", new_path);
+        }
+
+        let (logs, result) = capture_logs(|| emit_event("bad;touch owned.fish", &Event::Install));
+
+        assert!(result.is_ok());
+        assert!(!log_path.exists());
+        assert!(
+            logs.iter()
+                .any(|msg| msg.contains("unsafe event name stem"))
         );
     }
 


### PR DESCRIPTION
This pull request tightens security and correctness around emitting Fish shell events by ensuring that only "safe" event name stems (alphanumeric plus `_`, `-`, or `.`) are allowed. It updates documentation, implementation, and tests to reflect this new behavior, preventing unsafe stems from being used in event emission and improving the reliability of plugin event handling.

**Event emission security and correctness:**

* Added a check in `emit_event` (in `utils.rs`) to skip emitting Fish events for stems that contain unsafe characters, logging a warning instead. Only stems matching `[A-Za-z0-9_.-]+` are allowed. [[1]](diffhunk://#diff-23af5356f6001cd3993cd3c801fb7716ea02d1e504081b9fb569332db6107e80R348-R361) [[2]](diffhunk://#diff-23af5356f6001cd3993cd3c801fb7716ea02d1e504081b9fb569332db6107e80R378-R384)
* Updated documentation in `docs/architecture.md`, `docs/commands.md`, and `docs/configuration.md` to clarify that only safe stems are eligible for event emission, and explained what constitutes a safe stem. [[1]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L27-R27) [[2]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR112) [[3]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180L121-R128)

**Testing improvements:**

* Added new tests in `utils.rs` to verify that unsafe stems are skipped without spawning Fish, and that the event name is passed correctly as a Fish argument for safe stems.
* Updated existing tests in `install.rs`, `uninstall.rs`, and `upgrade.rs` to check for the presence/absence of event names rather than full `emit` command strings, reflecting the new event emission logic. [[1]](diffhunk://#diff-dd816aa02270455964eb003cdbeab3b63a9769f147c581421b38182d9e3c7a25L1348-R1349) [[2]](diffhunk://#diff-d9d60d1f6558bbac9286fbfa98881800972c7919f092038db697500e7f4a5f28L632-R633) [[3]](diffhunk://#diff-559b99cc491026d680606e6d4832064f42b2e7d384d86ec9ad384fb01c697e23L678-R679)