### PR TITLE
ci: harden Dependabot and pin CI actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -12,3 +14,5 @@ updates:
       github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: ${{ matrix.rust }}
       - run: cargo test --all-features
   formatting:
     name: cargo fmt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,26 +15,32 @@ jobs:
       matrix:
         rust: [stable, beta, nightly]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       - run: cargo test --all-features
   formatting:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           components: rustfmt
       - name: rustfmt check
-        uses: actions-rust-lang/rustfmt@v1
+        uses: actions-rust-lang/rustfmt@4066006ec54a31931b9b1fddfd38f2fdf2d27143 # v1.1.2
   clippy_check:
     name: cargo clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: "Install/Update the Rust version"
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           components: clippy
       - name: clippy "No Default Features"
@@ -47,8 +53,10 @@ jobs:
     name: config schema
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       - name: regenerate schema
         run: cargo run --features schema-gen --bin gen-config-schema
       - name: check schema up to date


### PR DESCRIPTION
This pull request updates CI workflows and Dependabot configuration to improve reliability and control update frequency. The most important changes are grouped below.

**CI Workflow Improvements:**

* All GitHub Actions in `.github/workflows/ci.yaml` now use explicit commit SHA references instead of floating version tags, improving security and reproducibility. (`actions/checkout`, `actions-rust-lang/setup-rust-toolchain`, and `actions-rust-lang/rustfmt` are now pinned to specific SHAs) [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL18-R43) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL50-R59)
* The `actions/checkout` step now sets `persist-credentials: false` to avoid leaking credentials to subsequent steps. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL18-R43) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL50-R59)

**Dependabot Configuration Enhancements:**

* Added a `cooldown` period of 7 days for both npm and GitHub Actions updates in `.github/dependabot.yaml` to limit the frequency of pull requests and reduce noise. [[1]](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cR7-R8) [[2]](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cR17-R18)