### PR TITLE
fix: fail closed on unresolved pinned refs

### DIFF
--- a/src/cmd/install.rs
+++ b/src/cmd/install.rs
@@ -120,6 +120,26 @@ fn cleanup_prepared_remote_repos(plugins: &[Plugin], pez_data_dir: &path::Path) 
     }
 }
 
+fn resolve_install_commit(
+    repo: &git2::Repository,
+    ref_kind: &resolver::RefKind,
+    source: &str,
+) -> anyhow::Result<String> {
+    let sel = resolver::selection_from_ref_kind(ref_kind);
+    match git::resolve_selection(repo, &sel) {
+        std::result::Result::Ok(sha) => Ok(sha),
+        Err(e) if resolver::ref_kind_allows_head_fallback(ref_kind) => {
+            warn!(
+                "Failed to resolve selection: {:?}. Falling back to HEAD.",
+                e
+            );
+            Ok(git::get_latest_commit_sha(repo)?)
+        }
+        Err(e) => Err(e)
+            .with_context(|| format!("failed to resolve requested ref for repository {source}")),
+    }
+}
+
 fn add_plugins_to_config(
     config: &mut config::Config,
     config_path: &path::Path,
@@ -325,17 +345,7 @@ fn prepare_plugin_from_resolved(
         let commit_sha = if let Some(locked) = locked_plugin {
             if force {
                 if let Some(repo) = &repo {
-                    let sel = resolver::selection_from_ref_kind(&ref_kind);
-                    match git::resolve_selection(repo, &sel) {
-                        std::result::Result::Ok(sha) => sha,
-                        Err(e) => {
-                            warn!(
-                                "Failed to resolve selection: {:?}. Falling back to HEAD.",
-                                e
-                            );
-                            git::get_latest_commit_sha(repo)?
-                        }
-                    }
+                    resolve_install_commit(repo, &ref_kind, &source_base)?
                 } else {
                     "local".to_string()
                 }
@@ -366,17 +376,7 @@ fn prepare_plugin_from_resolved(
             let repo = repo
                 .as_ref()
                 .ok_or_else(|| anyhow::anyhow!("expected cloned repository for remote source"))?;
-            let sel = resolver::selection_from_ref_kind(&ref_kind);
-            let commit_sha = match git::resolve_selection(repo, &sel) {
-                std::result::Result::Ok(sha) => sha,
-                Err(e) => {
-                    warn!(
-                        "Failed to resolve selection: {:?}. Falling back to HEAD.",
-                        e
-                    );
-                    git::get_latest_commit_sha(repo)?
-                }
-            };
+            let commit_sha = resolve_install_commit(repo, &ref_kind, &source_base)?;
             if let Err(e) = git::checkout_commit(repo, &commit_sha) {
                 warn!("Failed to detach HEAD to {}: {:?}", &commit_sha, e);
             }
@@ -1207,6 +1207,35 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn clone_plugins_fails_when_explicit_selector_is_unresolved() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let remote_repo_path = temp_dir.path().join("owner").join("missing-selector");
+        let remote_url = format!("file://{}", remote_repo_path.display());
+        init_remote_repo(&remote_repo_path);
+
+        let mut resolved = InstallTarget::from_raw(remote_url.clone())
+            .resolve()
+            .unwrap();
+        resolved.ref_kind = resolver::RefKind::Branch("missing-branch".to_string());
+        let data_dir = temp_dir.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let err = clone_plugins(
+            &[resolved.clone()],
+            false,
+            crate::lock_file::init(),
+            &data_dir,
+        )
+        .await
+        .unwrap_err();
+        let err_text = format!("{:#}", err);
+
+        assert!(err_text.contains("failed to prepare plugin"));
+        assert!(err_text.contains("Branch not found: missing-branch"));
+        assert!(!data_dir.join(resolved.plugin_repo.as_str()).exists());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn clone_plugins_rolls_back_successful_remote_clones_when_another_target_fails() {
         let temp_dir = tempfile::tempdir().unwrap();
         let good_remote_repo_path = temp_dir.path().join("owner").join("good-repo");
@@ -1801,7 +1830,7 @@ mod tests {
     }
 
     #[test]
-    fn install_all_force_unresolvable_selector_falls_back_to_head() {
+    fn install_all_force_unresolvable_selector_fails() {
         let _log_lock = crate::tests_support::log::env_lock().lock().unwrap();
         let mut test_env = TestEnvironmentSetup::new();
         let _override = EnvOverride::new(&[
@@ -1819,7 +1848,7 @@ mod tests {
             .path()
             .join("owner")
             .join("force-missing-selector");
-        let (first_commit, head_commit) = init_remote_repo_with_two_commits(&remote_repo_path);
+        let (first_commit, _head_commit) = init_remote_repo_with_two_commits(&remote_repo_path);
         let remote_url = format!("file://{}", remote_repo_path.display());
 
         let plugin_repo = PluginRepo {
@@ -1867,14 +1896,11 @@ mod tests {
         let force = true;
         let prune = false;
         let result = install_all(&force, &prune);
-        assert!(
-            result.is_ok(),
-            "install_all should succeed and fall back to HEAD when selector cannot be resolved"
-        );
+        let err_text = format!("{:#}", result.unwrap_err());
+        assert!(err_text.contains("missing-branch"), "{err_text}");
 
         let saved_lock = crate::lock_file::load(&test_env.lock_file_path).unwrap();
-        let updated_plugin = saved_lock.get_plugin_by_repo(&plugin_repo).unwrap();
-        assert_eq!(updated_plugin.commit_sha, head_commit);
-        assert_ne!(updated_plugin.commit_sha, first_commit);
+        let locked_plugin = saved_lock.get_plugin_by_repo(&plugin_repo).unwrap();
+        assert_eq!(locked_plugin.commit_sha, first_commit);
     }
 }

--- a/src/cmd/upgrade.rs
+++ b/src/cmd/upgrade.rs
@@ -3,9 +3,10 @@ use crate::{
     git,
     lock_file::Plugin,
     models::{PluginRepo, TargetDir},
-    utils,
+    resolver, utils,
 };
 
+use anyhow::Context;
 use console::Emoji;
 use futures::{StreamExt, stream};
 use std::fs;
@@ -84,6 +85,26 @@ async fn upgrade_all() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn resolve_upgrade_commit(
+    repo: &git2::Repository,
+    plugin_repo: &PluginRepo,
+    ref_kind: &resolver::RefKind,
+) -> anyhow::Result<String> {
+    let sel = resolver::selection_from_ref_kind(ref_kind);
+    match git::resolve_selection(repo, &sel) {
+        Ok(c) => Ok(c),
+        Err(e) if resolver::ref_kind_allows_head_fallback(ref_kind) => {
+            warn!(
+                "Failed to resolve selection for {}: {:?}. Falling back to remote HEAD.",
+                plugin_repo, e
+            );
+            git::get_latest_remote_commit(repo)
+        }
+        Err(e) => Err(e)
+            .with_context(|| format!("failed to resolve requested ref for plugin {plugin_repo}")),
+    }
+}
+
 fn upgrade_plugin(plugin_repo: &PluginRepo) -> anyhow::Result<()> {
     let (mut lock_file, lock_file_path) = utils::load_or_create_lock_file()?;
     let (config, _) = utils::load_or_create_config()?;
@@ -104,7 +125,7 @@ fn upgrade_plugin(plugin_repo: &PluginRepo) -> anyhow::Result<()> {
             if repo_path.exists() {
                 let repo = git2::Repository::open(&repo_path)?;
                 // Determine desired selection from config (if present); fall back to default head
-                let sel = config
+                let ref_kind = config
                     .plugins
                     .as_ref()
                     .and_then(|ps| {
@@ -112,19 +133,10 @@ fn upgrade_plugin(plugin_repo: &PluginRepo) -> anyhow::Result<()> {
                             .find(|p| p.get_plugin_repo().ok().as_ref() == Some(plugin_repo))
                             .and_then(|p| p.to_resolved().ok())
                     })
-                    .map(|r| crate::resolver::selection_from_ref_kind(&r.ref_kind))
-                    .unwrap_or(crate::resolver::Selection::DefaultHead);
+                    .map(|r| r.ref_kind)
+                    .unwrap_or(crate::resolver::RefKind::None);
 
-                let latest_remote_commit = match git::resolve_selection(&repo, &sel) {
-                    Ok(c) => c,
-                    Err(e) => {
-                        warn!(
-                            "Failed to resolve selection for {}: {:?}. Falling back to remote HEAD.",
-                            plugin_repo, e
-                        );
-                        git::get_latest_remote_commit(&repo)?
-                    }
-                };
+                let latest_remote_commit = resolve_upgrade_commit(&repo, plugin_repo, &ref_kind)?;
                 if latest_remote_commit == lock_file_plugin.commit_sha {
                     info!(
                         "{} {} Plugin {} is already up to date.",
@@ -573,6 +585,46 @@ mod tests {
         });
 
         upgrade_plugin(&fixture.repo).expect("upgrade should succeed");
+
+        let lock = lock_file::load(&fixture.env.lock_file_path).unwrap();
+        let updated = lock.get_plugin_by_repo(&fixture.repo).unwrap();
+        assert_eq!(updated.commit_sha, fixture.first_commit);
+    }
+
+    #[test]
+    fn upgrade_plugin_fails_when_explicit_selector_is_unresolved() {
+        let _lock = crate::tests_support::log::env_lock().lock().unwrap();
+        crate::utils::clear_cli_jobs_override_for_tests();
+        let mut fixture = UpgradeFixture::new(false);
+        let _override = EnvOverride::new(&[
+            "PEZ_SUPPRESS_EMIT",
+            "__fish_config_dir",
+            "PEZ_CONFIG_DIR",
+            "PEZ_DATA_DIR",
+        ]);
+        unsafe {
+            std::env::set_var("PEZ_SUPPRESS_EMIT", "1");
+            std::env::set_var("__fish_config_dir", &fixture.env.fish_config_dir);
+            std::env::set_var("PEZ_CONFIG_DIR", &fixture.env.config_dir);
+            std::env::set_var("PEZ_DATA_DIR", &fixture.env.data_dir);
+        }
+
+        fixture.env.setup_config(config::Config {
+            plugins: Some(vec![config::PluginSpec {
+                name: None,
+                source: config::PluginSource::Repo {
+                    repo: fixture.repo.clone(),
+                    version: None,
+                    branch: Some("missing-branch".into()),
+                    tag: None,
+                    commit: None,
+                },
+            }]),
+        });
+
+        let err = upgrade_plugin(&fixture.repo).expect_err("upgrade should fail");
+        let err_text = format!("{:#}", err);
+        assert!(err_text.contains("missing-branch"), "{err_text}");
 
         let lock = lock_file::load(&fixture.env.lock_file_path).unwrap();
         let updated = lock.get_plugin_by_repo(&fixture.repo).unwrap();

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -52,6 +52,10 @@ pub(crate) fn selection_from_ref_kind(kind: &RefKind) -> Selection {
     }
 }
 
+pub(crate) fn ref_kind_allows_head_fallback(kind: &RefKind) -> bool {
+    matches!(kind, RefKind::None | RefKind::Latest)
+}
+
 pub(crate) fn ref_kind_to_repo_source(repo: &PluginRepo, kind: &RefKind) -> PluginSource {
     match kind {
         RefKind::None => PluginSource::Repo {
@@ -187,5 +191,21 @@ mod tests {
             Selection::Version(v) => assert_eq!(v, "v3"),
             _ => panic!(),
         }
+    }
+
+    #[test]
+    fn only_default_and_latest_allow_head_fallback() {
+        assert!(ref_kind_allows_head_fallback(&RefKind::None));
+        assert!(ref_kind_allows_head_fallback(&RefKind::Latest));
+        assert!(!ref_kind_allows_head_fallback(&RefKind::Version(
+            "v1".into()
+        )));
+        assert!(!ref_kind_allows_head_fallback(&RefKind::Branch(
+            "main".into()
+        )));
+        assert!(!ref_kind_allows_head_fallback(&RefKind::Tag("v1".into())));
+        assert!(!ref_kind_allows_head_fallback(&RefKind::Commit(
+            "abc123".into()
+        )));
     }
 }


### PR DESCRIPTION
This pull request refactors how plugin installation and upgrade handle unresolved selectors, making the behavior stricter and more consistent. Previously, when a specific selector (like a branch, tag, or commit) could not be resolved, the system would fall back to using the HEAD commit. Now, fallback to HEAD is only allowed for default or "latest" selectors; explicit selectors must resolve successfully or the operation will fail. The changes also include new helper functions, improved error handling, and updated tests to reflect the new logic.

**Refactoring and stricter selector resolution:**

* Introduced `resolve_install_commit` and `resolve_upgrade_commit` helper functions to centralize logic for resolving the commit to install or upgrade, improving code reuse and clarity. These functions only allow fallback to HEAD for default or "latest" selectors, not for explicit selectors like branch or tag. [[1]](diffhunk://#diff-dd816aa02270455964eb003cdbeab3b63a9769f147c581421b38182d9e3c7a25R123-R142) [[2]](diffhunk://#diff-559b99cc491026d680606e6d4832064f42b2e7d384d86ec9ad384fb01c697e23R88-R107)
* Added `ref_kind_allows_head_fallback` function to define which selector types permit fallback to HEAD, and updated logic in install and upgrade flows to use this check.
* Updated install and upgrade code paths to use these new helpers, ensuring consistent behavior and improved error messages when explicit selectors are unresolved. [[1]](diffhunk://#diff-dd816aa02270455964eb003cdbeab3b63a9769f147c581421b38182d9e3c7a25L328-R348) [[2]](diffhunk://#diff-dd816aa02270455964eb003cdbeab3b63a9769f147c581421b38182d9e3c7a25L369-R379) [[3]](diffhunk://#diff-559b99cc491026d680606e6d4832064f42b2e7d384d86ec9ad384fb01c697e23L107-R139)

**Testing and validation:**

* Added and updated tests to verify that plugin installation and upgrade now fail when an explicit selector (e.g., a missing branch) cannot be resolved, and that fallback to HEAD only occurs for default selectors. [[1]](diffhunk://#diff-dd816aa02270455964eb003cdbeab3b63a9769f147c581421b38182d9e3c7a25R1209-R1237) [[2]](diffhunk://#diff-dd816aa02270455964eb003cdbeab3b63a9769f147c581421b38182d9e3c7a25L1804-R1833) [[3]](diffhunk://#diff-dd816aa02270455964eb003cdbeab3b63a9769f147c581421b38182d9e3c7a25L1822-R1851) [[4]](diffhunk://#diff-dd816aa02270455964eb003cdbeab3b63a9769f147c581421b38182d9e3c7a25L1870-R1904) [[5]](diffhunk://#diff-559b99cc491026d680606e6d4832064f42b2e7d384d86ec9ad384fb01c697e23R594-R633) [[6]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dR195-R210)

**Minor improvements:**

* Improved error context and logging for unresolved selectors, making failures easier to diagnose. [[1]](diffhunk://#diff-dd816aa02270455964eb003cdbeab3b63a9769f147c581421b38182d9e3c7a25R123-R142) [[2]](diffhunk://#diff-559b99cc491026d680606e6d4832064f42b2e7d384d86ec9ad384fb01c697e23R88-R107)
* Refactored imports to support new helper functions.