### PR TITLE
fix: harden plugin file path handling

### DIFF
--- a/src/lock_file.rs
+++ b/src/lock_file.rs
@@ -20,15 +20,28 @@ pub(crate) fn init() -> LockFile {
 
 pub(crate) fn load(path: &path::Path) -> anyhow::Result<LockFile> {
     let content = fs::read_to_string(path)?;
-    let lock_file = toml::from_str(&content)?;
+    let lock_file: LockFile = toml::from_str(&content)?;
+    lock_file.validate()?;
 
     Ok(lock_file)
 }
 
 impl LockFile {
     pub(crate) fn save(&self, path: &path::Path) -> anyhow::Result<()> {
+        self.validate()?;
+
         let contents = toml::to_string(self)?;
         fs::write(path, AUTO_GENERATED_COMMENT.to_string() + &contents)?;
+
+        Ok(())
+    }
+
+    fn validate(&self) -> anyhow::Result<()> {
+        for plugin in &self.plugins {
+            for file in &plugin.files {
+                file.validate_name()?;
+            }
+        }
 
         Ok(())
     }
@@ -153,6 +166,31 @@ impl Plugin {
 impl PluginFile {
     pub(crate) fn get_path(&self, config_dir: &path::Path) -> path::PathBuf {
         config_dir.join(self.dir.as_str()).join(&self.name)
+    }
+
+    fn validate_name(&self) -> anyhow::Result<()> {
+        if self.name.is_empty() {
+            anyhow::bail!(
+                "Invalid plugin file path for {}: {}",
+                self.dir.as_str(),
+                self.name
+            );
+        }
+
+        let file_path = path::Path::new(&self.name);
+        if file_path.is_absolute()
+            || !file_path
+                .components()
+                .all(|component| matches!(component, path::Component::Normal(_)))
+        {
+            anyhow::bail!(
+                "Invalid plugin file path for {}: {}",
+                self.dir.as_str(),
+                self.name
+            );
+        }
+
+        Ok(())
     }
 }
 
@@ -301,5 +339,67 @@ mod tests {
             files: vec![],
         };
         assert_eq!(unnamed.get_name(), "repo");
+    }
+
+    #[test]
+    fn load_rejects_parent_dir_plugin_file_name() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("pez-lock.toml");
+        fs::write(
+            &path,
+            r#"
+version = 1
+
+[[plugins]]
+name = "repo"
+repo = "owner/repo"
+source = "https://example.com/owner/repo"
+commit_sha = "deadbeef"
+files = [{ dir = "functions", name = "../config.fish" }]
+"#,
+        )
+        .unwrap();
+
+        let err = load(&path).expect_err("path traversal should be rejected");
+
+        assert!(
+            err.to_string().contains("Invalid plugin file path"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.to_string().contains("../config.fish"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn load_rejects_absolute_plugin_file_name() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("pez-lock.toml");
+        fs::write(
+            &path,
+            r#"
+version = 1
+
+[[plugins]]
+name = "repo"
+repo = "owner/repo"
+source = "https://example.com/owner/repo"
+commit_sha = "deadbeef"
+files = [{ dir = "functions", name = "/tmp/evil.fish" }]
+"#,
+        )
+        .unwrap();
+
+        let err = load(&path).expect_err("absolute path should be rejected");
+
+        assert!(
+            err.to_string().contains("Invalid plugin file path"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.to_string().contains("/tmp/evil.fish"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -211,7 +211,7 @@ pub(crate) fn copy_plugin_files(
             .filter_map(Result::ok)
         {
             let entry_path = entry.path();
-            if entry.file_type().is_dir() {
+            if !entry.file_type().is_file() {
                 continue;
             }
             if let Some(ext) = expected_ext
@@ -282,7 +282,7 @@ fn copy_plugin_files_recursive(
 
     for entry in WalkDir::new(target_path).into_iter().filter_map(Result::ok) {
         let entry_path = entry.path();
-        if entry.file_type().is_dir() {
+        if !entry.file_type().is_file() {
             continue;
         }
         if let Some(ext) = expected_ext
@@ -1133,6 +1133,46 @@ mod tests {
                 .fish_config_dir
                 .join("functions")
                 .join("nested/dir/tool.fish")
+                .exists()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_plugin_files_skips_symlinked_files() {
+        use std::os::unix::fs::symlink;
+
+        let test_env = TestEnvironmentSetup::new();
+        let mut test_data = TestDataBuilder::new().build();
+
+        let repo = test_data.plugin_spec.get_plugin_repo().unwrap();
+        let functions_dir = test_env
+            .data_dir
+            .join(repo.as_str())
+            .join(TargetDir::Functions.as_str());
+        std::fs::create_dir_all(&functions_dir).unwrap();
+
+        let linked_target = test_env._temp_dir.path().join("outside.fish");
+        std::fs::write(&linked_target, "function outside\nend\n").unwrap();
+        symlink(&linked_target, functions_dir.join("linked.fish")).unwrap();
+
+        let repo_path = test_env.data_dir.join(repo.as_str());
+        let outcome = copy_plugin_files(
+            &repo_path,
+            &test_env.fish_config_dir,
+            &mut test_data.plugin,
+            None,
+            false,
+        )
+        .expect("copy should succeed");
+
+        assert_eq!(outcome.file_count, 0);
+        assert!(test_data.plugin.files.is_empty());
+        assert!(
+            !test_env
+                .fish_config_dir
+                .join("functions")
+                .join("linked.fish")
                 .exists()
         );
     }


### PR DESCRIPTION
This pull request strengthens validation and security around plugin file handling in the lock file system, ensuring that only safe, relative file paths are accepted and that symlinked files are not processed. It also improves test coverage for these scenarios.

**Validation and Security Enhancements:**

* Added validation in `LockFile` and `PluginFile` to reject plugin file names that are empty, absolute paths, or contain path traversal components, preventing unsafe file paths from being accepted. [[1]](diffhunk://#diff-759e85f08fe907d9cd9e3a17b0bb5ba7e828df1f7508e6c01e49f62ce8bfde30L23-R48) [[2]](diffhunk://#diff-759e85f08fe907d9cd9e3a17b0bb5ba7e828df1f7508e6c01e49f62ce8bfde30R170-R194)
* Updated logic in `copy_plugin_files` and `copy_plugin_files_recursive` to skip non-regular files (such as directories and symlinks), further hardening file copy operations. [[1]](diffhunk://#diff-23af5356f6001cd3993cd3c801fb7716ea02d1e504081b9fb569332db6107e80L214-R214) [[2]](diffhunk://#diff-23af5356f6001cd3993cd3c801fb7716ea02d1e504081b9fb569332db6107e80L285-R285)

**Testing Improvements:**

* Added tests to ensure that loading a lock file with parent directory references or absolute paths in plugin file names is rejected with an appropriate error.
* Introduced a test to confirm that symlinked files are skipped during plugin file copying on Unix systems.