### PR TITLE
fix: preserve state on removal failures

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ This document outlines the high‑level structure and flows in pez.
 4. Resolve the commit using `resolver::RefKind` -> `git::resolve_selection`.
 5. Copy files to the Fish config directory using `utils::copy_plugin_files*`.
 6. Update the lockfile with `name`/`repo`/`source`/`commit_sha`/`files`.
-7. For files under `conf.d` with safe stems, emit `<stem>_{install|update|uninstall}` fish events.
+7. For files under `conf.d` with safe stems, emit `<stem>_{install|update|uninstall}` fish events at the command-specific hook point; raw uninstall emits run after cleanup and state updates succeed.
 
 ## Concurrency
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -109,7 +109,7 @@ Global options (apply to all commands)
 - Output shell activation code that wraps `pez` with hooks in the current shell.
 - Usage: `pez activate fish | source` (for persistence, add inside `if status is-interactive ... end` in `~/.config/fish/config.fish`).
 - Behavior: after `install`/`upgrade`, sources matching `conf.d` files and emits `<stem>_{install|update}` in the current shell; before `uninstall`, emits `<stem>_uninstall`.
-- Out-of-process event emits only run for safe stems (`A-Z`, `a-z`, `0-9`, `_`, `-`, or `.`).
+- Out-of-process event emits only run for safe stems (`A-Z`, `a-z`, `0-9`, `_`, `-`, or `.`); uninstall emits run only after cleanup and state updates succeed.
 - When active, the wrapper runs `pez` with `PEZ_SUPPRESS_EMIT=1` to avoid duplicate out-of-process emits.
 
 ### files

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,7 +118,7 @@ Notes
 - It copies files recursively into the matching Fish config directories, preserving relative paths.
 - Only `.fish` files are copied from `functions`/`completions`/`conf.d`, and only `.theme` files from `themes`.
 - If two plugins would write the same destination path in a single run, the later plugin is skipped and its files are not recorded in the lockfile.
-- For `conf.d` files with safe stems (`A-Z`, `a-z`, `0-9`, `_`, `-`, or `.`), pez emits `<stem>_{install|update|uninstall}` after installs/upgrades or before uninstalls (unless `PEZ_SUPPRESS_EMIT` is set).
+- For `conf.d` files with safe stems (`A-Z`, `a-z`, `0-9`, `_`, `-`, or `.`), pez emits out-of-process `<stem>_{install|update|uninstall}` events unless `PEZ_SUPPRESS_EMIT` is set. Raw uninstall emits run only after cleanup and state updates succeed; the activation wrapper sources and emits uninstall hooks before running `pez uninstall` in the current shell.
 
 ## Environment Variables and CLI Overrides
 

--- a/src/cmd/install.rs
+++ b/src/cmd/install.rs
@@ -1747,6 +1747,7 @@ mod tests {
         let _env_lock = crate::tests_support::log::env_lock().lock().unwrap();
         let mut test_env = TestEnvironmentSetup::new();
         let _override = EnvOverride::new(&[
+            "PATH",
             "PEZ_CONFIG_DIR",
             "PEZ_DATA_DIR",
             "PEZ_TARGET_DIR",

--- a/src/cmd/install.rs
+++ b/src/cmd/install.rs
@@ -633,12 +633,10 @@ fn install_all(force: &bool, prune: &bool) -> anyhow::Result<()> {
                     info!("   - {}", dest_path.display());
                 }
 
-                if repo_path.exists() {
-                    fs::remove_dir_all(&repo_path)?;
-                }
                 lock_file.remove_plugin(&plugin.source);
                 lock_file.save(&lock_file_path)?;
                 staged_removals.commit();
+                utils::remove_dir_all_best_effort(&repo_path);
                 emit_event(&plugin, &utils::Event::Uninstall)?;
             }
         } else {
@@ -1825,6 +1823,75 @@ mod tests {
             !log_path.exists(),
             "uninstall event should not be emitted when deletion is rejected"
         );
+    }
+
+    #[test]
+    fn install_all_prune_preserves_repo_when_lock_save_fails() {
+        let _env_lock = crate::tests_support::log::env_lock().lock().unwrap();
+        let mut test_env = TestEnvironmentSetup::new();
+        let _override = EnvOverride::new(&[
+            "PEZ_CONFIG_DIR",
+            "PEZ_DATA_DIR",
+            "PEZ_TARGET_DIR",
+            "__fish_config_dir",
+            "XDG_CONFIG_HOME",
+            "__fish_user_data_dir",
+            "XDG_DATA_HOME",
+            "HOME",
+            "PEZ_SUPPRESS_EMIT",
+        ]);
+
+        let repo = PluginRepo::new(None, "owner".to_string(), "blocked".to_string()).unwrap();
+        test_env.setup_config(config::Config {
+            plugins: Some(vec![]),
+        });
+        test_env.setup_lock_file(crate::lock_file::LockFile {
+            version: 1,
+            plugins: vec![Plugin {
+                name: repo.repo.clone(),
+                repo: repo.clone(),
+                source: repo.default_remote_source(),
+                commit_sha: "blocked-sha".to_string(),
+                files: vec![PluginFile {
+                    dir: TargetDir::ConfD,
+                    name: "blocked.fish".to_string(),
+                }],
+            }],
+        });
+        let repo_path = test_env.data_dir.join(repo.as_str());
+        std::fs::create_dir_all(&repo_path).unwrap();
+        let plugin_file = test_env
+            .fish_config_dir
+            .join(TargetDir::ConfD.as_str())
+            .join("blocked.fish");
+        std::fs::create_dir_all(plugin_file.parent().unwrap()).unwrap();
+        std::fs::write(&plugin_file, "echo blocked\n").unwrap();
+
+        set_test_env_vars(&test_env);
+        unsafe {
+            std::env::set_var("PEZ_SUPPRESS_EMIT", "1");
+        }
+        let original_perms = std::fs::metadata(&test_env.lock_file_path)
+            .unwrap()
+            .permissions();
+        let mut read_only_perms = original_perms.clone();
+        read_only_perms.set_mode(0o400);
+        std::fs::set_permissions(&test_env.lock_file_path, read_only_perms).unwrap();
+
+        let err = install_all(&true, &true).expect_err("lock save failure should abort prune");
+        std::fs::set_permissions(&test_env.lock_file_path, original_perms).unwrap();
+        let err_text = format!("{:#}", err);
+        assert!(err_text.contains("Permission denied"), "{err_text}");
+        assert!(
+            repo_path.exists(),
+            "repo directory should remain when lock save fails"
+        );
+        assert!(
+            plugin_file.exists(),
+            "staged plugin files should be restored when lock save fails"
+        );
+        let saved_lock = crate::lock_file::load(&test_env.lock_file_path).unwrap();
+        assert!(saved_lock.get_plugin_by_repo(&repo).is_some());
     }
 
     #[test]

--- a/src/cmd/install.rs
+++ b/src/cmd/install.rs
@@ -636,7 +636,7 @@ fn install_all(force: &bool, prune: &bool) -> anyhow::Result<()> {
                 lock_file.remove_plugin(&plugin.source);
                 lock_file.save(&lock_file_path)?;
                 staged_removals.commit();
-                utils::remove_dir_all_best_effort(&repo_path);
+                utils::remove_dir_all_if_exists(&repo_path)?;
                 emit_event(&plugin, &utils::Event::Uninstall)?;
             }
         } else {

--- a/src/cmd/install.rs
+++ b/src/cmd/install.rs
@@ -594,9 +594,14 @@ fn install_all(force: &bool, prune: &bool) -> anyhow::Result<()> {
             for plugin in ignored_lock_file_plugins {
                 info!("{}Removing plugin: {}", Emoji("🐟 ", ""), &plugin.name);
                 let repo_path = utils::load_pez_data_dir()?.join(plugin.repo.as_str());
-                if repo_path.exists() {
-                    fs::remove_dir_all(&repo_path)?;
-                } else {
+                let fish_config_dir = utils::load_fish_config_dir()?;
+                let file_paths: Vec<_> = plugin
+                    .files
+                    .iter()
+                    .map(|file| file.get_path(&fish_config_dir))
+                    .collect();
+
+                if !repo_path.exists() {
                     let path_display = repo_path.display();
                     warn!(
                         "{}Repository directory at {} does not exist.",
@@ -609,16 +614,18 @@ fn install_all(force: &bool, prune: &bool) -> anyhow::Result<()> {
                             "{}Detected plugin files based on pez-lock.toml:",
                             Emoji("📄 ", ""),
                         );
-                        let fish_config_dir = utils::load_fish_config_dir()?;
 
-                        plugin.files.iter().for_each(|file| {
-                            let dest_path =
-                                fish_config_dir.join(file.dir.as_str()).join(&file.name);
-                            info!("   - {}", dest_path.display());
-                        });
+                        file_paths
+                            .iter()
+                            .for_each(|dest_path| info!("   - {}", dest_path.display()));
                         info!("If you want to remove these files, use the --force flag.");
                         continue;
                     }
+                }
+
+                utils::ensure_files_removable(&file_paths)?;
+                if repo_path.exists() {
+                    fs::remove_dir_all(&repo_path)?;
                 }
 
                 info!(
@@ -626,19 +633,14 @@ fn install_all(force: &bool, prune: &bool) -> anyhow::Result<()> {
                     Emoji("🗑️  ", ""),
                 );
 
-                emit_event(&plugin, &utils::Event::Uninstall)?;
-
-                let fish_config_dir = utils::load_fish_config_dir()?;
-                for file in &plugin.files {
-                    let dest_path = fish_config_dir.join(file.dir.as_str()).join(&file.name);
-                    if utils::remove_file_if_exists(&dest_path)? {
+                for dest_path in &file_paths {
+                    if utils::remove_file_if_exists(dest_path)? {
                         info!("   - {}", dest_path.display());
                     }
                 }
                 lock_file.remove_plugin(&plugin.source);
-                if let Err(e) = lock_file.save(&lock_file_path) {
-                    warn!("Failed to save lock file: {:?}", e);
-                }
+                lock_file.save(&lock_file_path)?;
+                emit_event(&plugin, &utils::Event::Uninstall)?;
             }
         } else {
             info!(
@@ -951,6 +953,7 @@ mod tests {
         let _env_lock = crate::tests_support::log::env_lock().lock().unwrap();
         let test_env = TestEnvironmentSetup::new();
         let _override = EnvOverride::new(&[
+            "PATH",
             "PEZ_CONFIG_DIR",
             "PEZ_DATA_DIR",
             "PEZ_TARGET_DIR",
@@ -1754,6 +1757,16 @@ mod tests {
             "HOME",
             "PEZ_SUPPRESS_EMIT",
         ]);
+        let temp_dir = tempfile::tempdir().unwrap();
+        let bin_dir = temp_dir.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let log_path = temp_dir.path().join("fish.log");
+        let fish_path = bin_dir.join("fish");
+        let script = format!("#!/bin/sh\n\necho \"$@\" >> \"{}\"\n", log_path.display());
+        std::fs::write(&fish_path, script).unwrap();
+        let mut perms = std::fs::metadata(&fish_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fish_path, perms).unwrap();
 
         let repo = PluginRepo::new(None, "owner".to_string(), "blocked".to_string()).unwrap();
         test_env.setup_config(config::Config {
@@ -1767,21 +1780,25 @@ mod tests {
                 source: repo.default_remote_source(),
                 commit_sha: "blocked-sha".to_string(),
                 files: vec![PluginFile {
-                    dir: TargetDir::Functions,
+                    dir: TargetDir::ConfD,
                     name: "blocked.fish".to_string(),
                 }],
             }],
         });
+        let repo_path = test_env.data_dir.join(repo.as_str());
+        std::fs::create_dir_all(&repo_path).unwrap();
 
         let blocked_path = test_env
             .fish_config_dir
-            .join(TargetDir::Functions.as_str())
+            .join(TargetDir::ConfD.as_str())
             .join("blocked.fish");
         std::fs::create_dir_all(&blocked_path).unwrap();
 
         set_test_env_vars(&test_env);
+        let existing_path = std::env::var("PATH").unwrap_or_default();
         unsafe {
-            std::env::set_var("PEZ_SUPPRESS_EMIT", "1");
+            std::env::set_var("PATH", format!("{}:{}", bin_dir.display(), existing_path));
+            std::env::remove_var("PEZ_SUPPRESS_EMIT");
         }
 
         let force = true;
@@ -1793,6 +1810,14 @@ mod tests {
         let saved_lock = crate::lock_file::load(&test_env.lock_file_path).unwrap();
         assert!(saved_lock.get_plugin_by_repo(&repo).is_some());
         assert!(blocked_path.is_dir());
+        assert!(
+            repo_path.exists(),
+            "repo directory should remain when file deletion is rejected"
+        );
+        assert!(
+            !log_path.exists(),
+            "uninstall event should not be emitted when deletion is rejected"
+        );
     }
 
     #[test]

--- a/src/cmd/install.rs
+++ b/src/cmd/install.rs
@@ -593,8 +593,7 @@ fn install_all(force: &bool, prune: &bool) -> anyhow::Result<()> {
         if *prune {
             for plugin in ignored_lock_file_plugins {
                 info!("{}Removing plugin: {}", Emoji("🐟 ", ""), &plugin.name);
-                let repo_path = utils::load_pez_data_dir()?.join(plugin.repo.as_str());
-                let fish_config_dir = utils::load_fish_config_dir()?;
+                let repo_path = pez_data_dir.join(plugin.repo.as_str());
                 let file_paths: Vec<_> = plugin
                     .files
                     .iter()

--- a/src/cmd/install.rs
+++ b/src/cmd/install.rs
@@ -622,21 +622,23 @@ fn install_all(force: &bool, prune: &bool) -> anyhow::Result<()> {
                     }
                 }
 
-                let staged_removals = utils::stage_files_for_removal(&file_paths)?;
+                let staged_file_removals = utils::stage_files_for_removal(&file_paths)?;
+                let staged_repo_removals =
+                    utils::stage_dirs_for_removal(std::slice::from_ref(&repo_path))?;
 
                 info!(
                     "{}Removing plugin files based on pez-lock.toml:",
                     Emoji("🗑️  ", ""),
                 );
 
-                for dest_path in staged_removals.removed_paths() {
+                for dest_path in staged_file_removals.removed_paths() {
                     info!("   - {}", dest_path.display());
                 }
 
                 lock_file.remove_plugin(&plugin.source);
                 lock_file.save(&lock_file_path)?;
-                staged_removals.commit();
-                utils::remove_dir_all_if_exists(&repo_path)?;
+                staged_file_removals.commit();
+                staged_repo_removals.commit();
                 emit_event(&plugin, &utils::Event::Uninstall)?;
             }
         } else {

--- a/src/cmd/install.rs
+++ b/src/cmd/install.rs
@@ -623,23 +623,23 @@ fn install_all(force: &bool, prune: &bool) -> anyhow::Result<()> {
                     }
                 }
 
-                utils::ensure_files_removable(&file_paths)?;
-                if repo_path.exists() {
-                    fs::remove_dir_all(&repo_path)?;
-                }
+                let staged_removals = utils::stage_files_for_removal(&file_paths)?;
 
                 info!(
                     "{}Removing plugin files based on pez-lock.toml:",
                     Emoji("🗑️  ", ""),
                 );
 
-                for dest_path in &file_paths {
-                    if utils::remove_file_if_exists(dest_path)? {
-                        info!("   - {}", dest_path.display());
-                    }
+                for dest_path in staged_removals.removed_paths() {
+                    info!("   - {}", dest_path.display());
+                }
+
+                if repo_path.exists() {
+                    fs::remove_dir_all(&repo_path)?;
                 }
                 lock_file.remove_plugin(&plugin.source);
                 lock_file.save(&lock_file_path)?;
+                staged_removals.commit();
                 emit_event(&plugin, &utils::Event::Uninstall)?;
             }
         } else {
@@ -1792,7 +1792,13 @@ mod tests {
             .fish_config_dir
             .join(TargetDir::ConfD.as_str())
             .join("blocked.fish");
-        std::fs::create_dir_all(&blocked_path).unwrap();
+        std::fs::create_dir_all(blocked_path.parent().unwrap()).unwrap();
+        std::fs::write(&blocked_path, "echo blocked\n").unwrap();
+        let conf_d_dir = blocked_path.parent().unwrap();
+        let original_perms = std::fs::metadata(conf_d_dir).unwrap().permissions();
+        let mut read_only_perms = original_perms.clone();
+        read_only_perms.set_mode(0o500);
+        std::fs::set_permissions(conf_d_dir, read_only_perms).unwrap();
 
         set_test_env_vars(&test_env);
         let existing_path = std::env::var("PATH").unwrap_or_default();
@@ -1804,12 +1810,13 @@ mod tests {
         let force = true;
         let prune = true;
         let err = install_all(&force, &prune).expect_err("file removal failure should abort prune");
+        std::fs::set_permissions(conf_d_dir, original_perms).unwrap();
         let err_text = format!("{:#}", err);
         assert!(err_text.contains("Failed to remove"), "{err_text}");
 
         let saved_lock = crate::lock_file::load(&test_env.lock_file_path).unwrap();
         assert!(saved_lock.get_plugin_by_repo(&repo).is_some());
-        assert!(blocked_path.is_dir());
+        assert!(blocked_path.is_file());
         assert!(
             repo_path.exists(),
             "repo directory should remain when file deletion is rejected"

--- a/src/cmd/install.rs
+++ b/src/cmd/install.rs
@@ -631,10 +631,8 @@ fn install_all(force: &bool, prune: &bool) -> anyhow::Result<()> {
                 let fish_config_dir = utils::load_fish_config_dir()?;
                 for file in &plugin.files {
                     let dest_path = fish_config_dir.join(file.dir.as_str()).join(&file.name);
-                    if dest_path.exists()
-                        && let Err(e) = fs::remove_file(&dest_path)
-                    {
-                        warn!("Failed to remove {}: {:?}", dest_path.display(), e);
+                    if utils::remove_file_if_exists(&dest_path)? {
+                        info!("   - {}", dest_path.display());
                     }
                 }
                 lock_file.remove_plugin(&plugin.source);
@@ -1739,6 +1737,62 @@ mod tests {
             .collect();
         assert!(ignored_lines.iter().any(|line| line.contains("extra")));
         assert!(!ignored_lines.iter().any(|line| line.contains("keep")));
+    }
+
+    #[test]
+    fn install_all_prune_preserves_lock_when_plugin_file_removal_fails() {
+        let _env_lock = crate::tests_support::log::env_lock().lock().unwrap();
+        let mut test_env = TestEnvironmentSetup::new();
+        let _override = EnvOverride::new(&[
+            "PEZ_CONFIG_DIR",
+            "PEZ_DATA_DIR",
+            "PEZ_TARGET_DIR",
+            "__fish_config_dir",
+            "XDG_CONFIG_HOME",
+            "__fish_user_data_dir",
+            "XDG_DATA_HOME",
+            "HOME",
+            "PEZ_SUPPRESS_EMIT",
+        ]);
+
+        let repo = PluginRepo::new(None, "owner".to_string(), "blocked".to_string()).unwrap();
+        test_env.setup_config(config::Config {
+            plugins: Some(vec![]),
+        });
+        test_env.setup_lock_file(crate::lock_file::LockFile {
+            version: 1,
+            plugins: vec![Plugin {
+                name: repo.repo.clone(),
+                repo: repo.clone(),
+                source: repo.default_remote_source(),
+                commit_sha: "blocked-sha".to_string(),
+                files: vec![PluginFile {
+                    dir: TargetDir::Functions,
+                    name: "blocked.fish".to_string(),
+                }],
+            }],
+        });
+
+        let blocked_path = test_env
+            .fish_config_dir
+            .join(TargetDir::Functions.as_str())
+            .join("blocked.fish");
+        std::fs::create_dir_all(&blocked_path).unwrap();
+
+        set_test_env_vars(&test_env);
+        unsafe {
+            std::env::set_var("PEZ_SUPPRESS_EMIT", "1");
+        }
+
+        let force = true;
+        let prune = true;
+        let err = install_all(&force, &prune).expect_err("file removal failure should abort prune");
+        let err_text = format!("{:#}", err);
+        assert!(err_text.contains("Failed to remove"), "{err_text}");
+
+        let saved_lock = crate::lock_file::load(&test_env.lock_file_path).unwrap();
+        assert!(saved_lock.get_plugin_by_repo(&repo).is_some());
+        assert!(blocked_path.is_dir());
     }
 
     #[test]

--- a/src/cmd/prune.rs
+++ b/src/cmd/prune.rs
@@ -126,9 +126,12 @@ where
 
     for plugin in remove_plugins {
         let repo_path = ctx.data_dir.join(plugin.repo.as_str());
-        if repo_path.exists() {
-            fs::remove_dir_all(&repo_path)?;
-        } else {
+        let file_paths: Vec<_> = plugin
+            .files
+            .iter()
+            .map(|file| file.get_path(ctx.fish_config_dir))
+            .collect();
+        if !repo_path.exists() {
             let path_display = repo_path.display();
             warn!(
                 "{} {} Repository directory at {} does not exist.",
@@ -143,22 +146,25 @@ where
                     Emoji("📄 ", ""),
                 );
 
-                plugin.files.iter().for_each(|file| {
-                    let dest_path = file.get_path(ctx.fish_config_dir);
-                    info!("   - {}", dest_path.display());
-                });
+                file_paths
+                    .iter()
+                    .for_each(|dest_path| info!("   - {}", dest_path.display()));
                 info!("If you want to remove these files, use the --force flag.");
                 continue;
             }
+        }
+
+        utils::ensure_files_removable(&file_paths)?;
+        if repo_path.exists() {
+            fs::remove_dir_all(&repo_path)?;
         }
 
         info!(
             "{}Removing plugin files based on pez-lock.toml:",
             Emoji("🗑️  ", ""),
         );
-        for file in &plugin.files {
-            let dest_path = file.get_path(ctx.fish_config_dir);
-            if utils::remove_file_if_exists(&dest_path)? {
+        for dest_path in &file_paths {
+            if utils::remove_file_if_exists(dest_path)? {
                 info!("   - {}", dest_path.display());
             }
         }
@@ -224,9 +230,12 @@ where
             let data_dir = data_dir.clone();
             async move {
                 let repo_path = data_dir.join(plugin.repo.as_str());
-                if repo_path.exists() {
-                    tokio::task::spawn_blocking(move || fs::remove_dir_all(&repo_path)).await??;
-                } else {
+                let file_paths: Vec<_> = plugin
+                    .files
+                    .iter()
+                    .map(|file| file.get_path(&fish_config_dir))
+                    .collect();
+                if !repo_path.exists() {
                     let path_display = repo_path.display();
                     warn!(
                         "{} {} Repository directory at {} does not exist.",
@@ -248,12 +257,16 @@ where
                     }
                 }
 
+                utils::ensure_files_removable(&file_paths)?;
+                if repo_path.exists() {
+                    tokio::task::spawn_blocking(move || fs::remove_dir_all(&repo_path)).await??;
+                }
+
                 info!(
                     "{}Removing plugin files based on pez-lock.toml:",
                     Emoji("🗑️  ", ""),
                 );
-                for file in &plugin.files {
-                    let dest_path = fish_config_dir.join(file.dir.as_str()).join(&file.name);
+                for dest_path in &file_paths {
                     let to_delete = dest_path.clone();
                     let removed = tokio::task::spawn_blocking(move || {
                         utils::remove_file_if_exists(&to_delete)
@@ -786,6 +799,42 @@ mod tests {
     }
 
     #[test]
+    fn prune_preserves_repo_when_plugin_file_removal_fails() {
+        let mut test_env = TestEnvironmentSetup::new();
+        let test_data = TestDataBuilder::new().build();
+        let unused_repo = test_data.unused_plugin.repo.clone();
+        test_env.setup_config(config::Config {
+            plugins: Some(vec![test_data.used_plugin_spec]),
+        });
+        test_env.setup_lock_file(LockFile {
+            version: 1,
+            plugins: vec![test_data.used_plugin, test_data.unused_plugin],
+        });
+        test_env.setup_data_repo(test_env.lock_file.as_ref().unwrap().get_plugin_repos());
+
+        let blocked_path = test_env
+            .fish_config_dir
+            .join(TargetDir::Functions.as_str())
+            .join("unused.fish");
+        std::fs::create_dir_all(&blocked_path).unwrap();
+
+        let mut ctx = test_env.create_context();
+
+        let err = prune(true, false, || Ok(false), &mut ctx)
+            .expect_err("file removal failure should abort prune");
+        let err_text = format!("{:#}", err);
+        assert!(err_text.contains("Failed to remove"), "{err_text}");
+
+        let lock_file = lock_file::load(ctx.lock_file_path).unwrap();
+        assert!(lock_file.get_plugin_by_repo(&unused_repo).is_some());
+        assert!(
+            fs::metadata(ctx.data_dir.join("owner/unused-repo")).is_ok(),
+            "Unused repo directory should remain when file deletion is rejected"
+        );
+        assert!(blocked_path.is_dir());
+    }
+
+    #[test]
     fn test_prune_empty_config_missing_data_dir_without_force() {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
@@ -859,6 +908,7 @@ mod tests {
             version: 1,
             plugins: vec![test_data.used_plugin, test_data.unused_plugin],
         });
+        test_env.setup_data_repo(test_env.lock_file.as_ref().unwrap().get_plugin_repos());
 
         let blocked_path = test_env
             .fish_config_dir
@@ -876,6 +926,10 @@ mod tests {
         let saved = lock_file::load(ctx.lock_file_path).unwrap();
         assert!(saved.get_plugin_by_repo(&unused_repo).is_some());
         assert!(blocked_path.is_dir());
+        assert!(
+            fs::metadata(ctx.data_dir.join("owner/unused-repo")).is_ok(),
+            "Unused repo directory should remain when file deletion is rejected"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/cmd/prune.rs
+++ b/src/cmd/prune.rs
@@ -154,22 +154,22 @@ where
             }
         }
 
-        utils::ensure_files_removable(&file_paths)?;
-        if repo_path.exists() {
-            fs::remove_dir_all(&repo_path)?;
-        }
+        let staged_removals = utils::stage_files_for_removal(&file_paths)?;
 
         info!(
             "{}Removing plugin files based on pez-lock.toml:",
             Emoji("🗑️  ", ""),
         );
-        for dest_path in &file_paths {
-            if utils::remove_file_if_exists(dest_path)? {
-                info!("   - {}", dest_path.display());
-            }
+        for dest_path in staged_removals.removed_paths() {
+            info!("   - {}", dest_path.display());
+        }
+
+        if repo_path.exists() {
+            fs::remove_dir_all(&repo_path)?;
         }
         ctx.lock_file.remove_plugin(&plugin.source);
         ctx.lock_file.save(ctx.lock_file_path)?;
+        staged_removals.commit();
     }
     info!(
         "\n{}All uninstalled plugins have been pruned successfully!",
@@ -253,41 +253,38 @@ where
                                 fish_config_dir.join(file.dir.as_str()).join(&file.name);
                             info!("   - {}", dest_path.display());
                         }
-                        return Ok::<Option<String>, anyhow::Error>(None);
+                        return Ok::<Option<(String, utils::StagedFileRemovals)>, anyhow::Error>(
+                            None,
+                        );
                     }
                 }
 
-                utils::ensure_files_removable(&file_paths)?;
-                if repo_path.exists() {
-                    tokio::task::spawn_blocking(move || fs::remove_dir_all(&repo_path)).await??;
-                }
+                let staged_removals = utils::stage_files_for_removal(&file_paths)?;
 
                 info!(
                     "{}Removing plugin files based on pez-lock.toml:",
                     Emoji("🗑️  ", ""),
                 );
-                for dest_path in &file_paths {
-                    let to_delete = dest_path.clone();
-                    let removed = tokio::task::spawn_blocking(move || {
-                        utils::remove_file_if_exists(&to_delete)
-                    })
-                    .await
-                    .map_err(|e| anyhow::anyhow!(e))??;
-                    if removed {
-                        info!("   - {}", dest_path.display());
-                    }
+                for dest_path in staged_removals.removed_paths() {
+                    info!("   - {}", dest_path.display());
                 }
 
-                Ok(Some(plugin.source.clone()))
+                if repo_path.exists() {
+                    tokio::task::spawn_blocking(move || fs::remove_dir_all(&repo_path)).await??;
+                }
+
+                Ok(Some((plugin.source.clone(), staged_removals)))
             }
         })
         .buffer_unordered(jobs);
 
     let mut sources_to_remove: Vec<String> = Vec::new();
+    let mut staged_removals = Vec::new();
     futures::pin_mut!(tasks);
     while let Some(res) = tasks.next().await {
-        if let Some(source) = res? {
+        if let Some((source, removals)) = res? {
             sources_to_remove.push(source);
+            staged_removals.push(removals);
         }
     }
 
@@ -296,6 +293,9 @@ where
             .plugins
             .retain(|p| !sources_to_remove.contains(&p.source));
         ctx.lock_file.save(ctx.lock_file_path)?;
+        for removals in staged_removals {
+            removals.commit();
+        }
     }
 
     info!(
@@ -422,7 +422,7 @@ impl Drop for ConfirmInputGuard {
 
 #[cfg(test)]
 mod tests {
-    use std::{ffi::OsString, future::Future, vec};
+    use std::{ffi::OsString, future::Future, os::unix::fs::PermissionsExt, vec};
 
     use super::*;
     use crate::tests_support::log::{capture_logs, env_lock};
@@ -816,12 +816,19 @@ mod tests {
             .fish_config_dir
             .join(TargetDir::Functions.as_str())
             .join("unused.fish");
-        std::fs::create_dir_all(&blocked_path).unwrap();
+        std::fs::create_dir_all(blocked_path.parent().unwrap()).unwrap();
+        std::fs::write(&blocked_path, "echo blocked\n").unwrap();
+        let functions_dir = blocked_path.parent().unwrap();
+        let original_perms = std::fs::metadata(functions_dir).unwrap().permissions();
+        let mut read_only_perms = original_perms.clone();
+        read_only_perms.set_mode(0o500);
+        std::fs::set_permissions(functions_dir, read_only_perms).unwrap();
 
         let mut ctx = test_env.create_context();
 
         let err = prune(true, false, || Ok(false), &mut ctx)
             .expect_err("file removal failure should abort prune");
+        std::fs::set_permissions(functions_dir, original_perms).unwrap();
         let err_text = format!("{:#}", err);
         assert!(err_text.contains("Failed to remove"), "{err_text}");
 
@@ -831,7 +838,7 @@ mod tests {
             fs::metadata(ctx.data_dir.join("owner/unused-repo")).is_ok(),
             "Unused repo directory should remain when file deletion is rejected"
         );
-        assert!(blocked_path.is_dir());
+        assert!(blocked_path.is_file());
     }
 
     #[test]
@@ -914,18 +921,25 @@ mod tests {
             .fish_config_dir
             .join(TargetDir::Functions.as_str())
             .join("unused.fish");
-        std::fs::create_dir_all(&blocked_path).unwrap();
+        std::fs::create_dir_all(blocked_path.parent().unwrap()).unwrap();
+        std::fs::write(&blocked_path, "echo blocked\n").unwrap();
+        let functions_dir = blocked_path.parent().unwrap();
+        let original_perms = std::fs::metadata(functions_dir).unwrap().permissions();
+        let mut read_only_perms = original_perms.clone();
+        read_only_perms.set_mode(0o500);
+        std::fs::set_permissions(functions_dir, read_only_perms).unwrap();
 
         let mut ctx = test_env.create_context();
         let err = prune_parallel_with_confirm(true, true, &mut ctx, || Ok(true))
             .await
             .expect_err("file removal failure should abort prune");
+        std::fs::set_permissions(functions_dir, original_perms).unwrap();
         let err_text = format!("{:#}", err);
         assert!(err_text.contains("Failed to remove"), "{err_text}");
 
         let saved = lock_file::load(ctx.lock_file_path).unwrap();
         assert!(saved.get_plugin_by_repo(&unused_repo).is_some());
-        assert!(blocked_path.is_dir());
+        assert!(blocked_path.is_file());
         assert!(
             fs::metadata(ctx.data_dir.join("owner/unused-repo")).is_ok(),
             "Unused repo directory should remain when file deletion is rejected"

--- a/src/cmd/prune.rs
+++ b/src/cmd/prune.rs
@@ -259,7 +259,10 @@ where
                     }
                 }
 
-                let staged_removals = utils::stage_files_for_removal(&file_paths)?;
+                let staged_removals = tokio::task::spawn_blocking(move || {
+                    utils::stage_files_for_removal(&file_paths)
+                })
+                .await??;
 
                 info!(
                     "{}Removing plugin files based on pez-lock.toml:",

--- a/src/cmd/prune.rs
+++ b/src/cmd/prune.rs
@@ -167,7 +167,7 @@ where
         ctx.lock_file.remove_plugin(&plugin.source);
         ctx.lock_file.save(ctx.lock_file_path)?;
         staged_removals.commit();
-        utils::remove_dir_all_best_effort(&repo_path);
+        utils::remove_dir_all_if_exists(&repo_path)?;
     }
     info!(
         "\n{}All uninstalled plugins have been pruned successfully!",
@@ -297,7 +297,7 @@ where
             removals.commit();
         }
         for repo_path in repo_paths {
-            utils::remove_dir_all_best_effort(&repo_path);
+            utils::remove_dir_all_if_exists(&repo_path)?;
         }
     }
 

--- a/src/cmd/prune.rs
+++ b/src/cmd/prune.rs
@@ -154,20 +154,21 @@ where
             }
         }
 
-        let staged_removals = utils::stage_files_for_removal(&file_paths)?;
+        let staged_file_removals = utils::stage_files_for_removal(&file_paths)?;
+        let staged_repo_removals = utils::stage_dirs_for_removal(std::slice::from_ref(&repo_path))?;
 
         info!(
             "{}Removing plugin files based on pez-lock.toml:",
             Emoji("🗑️  ", ""),
         );
-        for dest_path in staged_removals.removed_paths() {
+        for dest_path in staged_file_removals.removed_paths() {
             info!("   - {}", dest_path.display());
         }
 
         ctx.lock_file.remove_plugin(&plugin.source);
         ctx.lock_file.save(ctx.lock_file_path)?;
-        staged_removals.commit();
-        utils::remove_dir_all_if_exists(&repo_path)?;
+        staged_file_removals.commit();
+        staged_repo_removals.commit();
     }
     info!(
         "\n{}All uninstalled plugins have been pruned successfully!",
@@ -252,39 +253,45 @@ where
                             info!("   - {}", dest_path.display());
                         }
                         return Ok::<
-                            Option<(String, utils::StagedFileRemovals, path::PathBuf)>,
+                            Option<(String, utils::StagedFileRemovals, utils::StagedDirRemovals)>,
                             anyhow::Error,
                         >(None);
                     }
                 }
 
-                let staged_removals = tokio::task::spawn_blocking(move || {
+                let staged_file_removals = tokio::task::spawn_blocking(move || {
                     utils::stage_files_for_removal(&file_paths)
                 })
                 .await??;
+                let staged_repo_removals =
+                    utils::stage_dirs_for_removal(std::slice::from_ref(&repo_path))?;
 
                 info!(
                     "{}Removing plugin files based on pez-lock.toml:",
                     Emoji("🗑️  ", ""),
                 );
-                for dest_path in staged_removals.removed_paths() {
+                for dest_path in staged_file_removals.removed_paths() {
                     info!("   - {}", dest_path.display());
                 }
 
-                Ok(Some((plugin.source.clone(), staged_removals, repo_path)))
+                Ok(Some((
+                    plugin.source.clone(),
+                    staged_file_removals,
+                    staged_repo_removals,
+                )))
             }
         })
         .buffer_unordered(jobs);
 
     let mut sources_to_remove: Vec<String> = Vec::new();
-    let mut staged_removals = Vec::new();
-    let mut repo_paths = Vec::new();
+    let mut staged_file_removals = Vec::new();
+    let mut staged_repo_removals = Vec::new();
     futures::pin_mut!(tasks);
     while let Some(res) = tasks.next().await {
-        if let Some((source, removals, repo_path)) = res? {
+        if let Some((source, file_removals, repo_removals)) = res? {
             sources_to_remove.push(source);
-            staged_removals.push(removals);
-            repo_paths.push(repo_path);
+            staged_file_removals.push(file_removals);
+            staged_repo_removals.push(repo_removals);
         }
     }
 
@@ -293,11 +300,11 @@ where
             .plugins
             .retain(|p| !sources_to_remove.contains(&p.source));
         ctx.lock_file.save(ctx.lock_file_path)?;
-        for removals in staged_removals {
+        for removals in staged_file_removals {
             removals.commit();
         }
-        for repo_path in repo_paths {
-            utils::remove_dir_all_if_exists(&repo_path)?;
+        for removals in staged_repo_removals {
+            removals.commit();
         }
     }
 
@@ -425,7 +432,7 @@ impl Drop for ConfirmInputGuard {
 
 #[cfg(test)]
 mod tests {
-    use std::{ffi::OsString, fs, future::Future, os::unix::fs::PermissionsExt, vec};
+    use std::{ffi::OsString, fs, future::Future, vec};
 
     use super::*;
     use crate::tests_support::log::{capture_logs, env_lock};
@@ -436,6 +443,8 @@ mod tests {
         tests_support::env::TestEnvironmentSetup,
     };
     use config::{PluginSource, PluginSpec};
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
 
     struct EnvOverride {
         keys: Vec<&'static str>,
@@ -801,6 +810,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn prune_preserves_repo_when_plugin_file_removal_fails() {
         let mut test_env = TestEnvironmentSetup::new();
@@ -844,6 +854,7 @@ mod tests {
         assert!(blocked_path.is_file());
     }
 
+    #[cfg(unix)]
     #[test]
     fn prune_preserves_repo_when_lock_save_fails() {
         let mut test_env = TestEnvironmentSetup::new();
@@ -949,6 +960,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[tokio::test(flavor = "multi_thread")]
     async fn prune_parallel_preserves_lock_when_plugin_file_removal_fails() {
         let _jobs = JobsGuard::set(1);
@@ -993,6 +1005,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[tokio::test(flavor = "multi_thread")]
     async fn prune_parallel_preserves_repo_when_lock_save_fails() {
         let _jobs = JobsGuard::set(1);

--- a/src/cmd/prune.rs
+++ b/src/cmd/prune.rs
@@ -156,16 +156,12 @@ where
             "{}Removing plugin files based on pez-lock.toml:",
             Emoji("🗑️  ", ""),
         );
-        plugin.files.iter().for_each(|file| {
+        for file in &plugin.files {
             let dest_path = file.get_path(ctx.fish_config_dir);
-            if dest_path.exists() {
-                let path_display = dest_path.display();
-                info!("   - {}", path_display);
-                if let Err(e) = fs::remove_file(&dest_path) {
-                    warn!("Failed to remove {}: {:?}", path_display, e);
-                }
+            if utils::remove_file_if_exists(&dest_path)? {
+                info!("   - {}", dest_path.display());
             }
-        });
+        }
         ctx.lock_file.remove_plugin(&plugin.source);
         ctx.lock_file.save(ctx.lock_file_path)?;
     }
@@ -258,12 +254,14 @@ where
                 );
                 for file in &plugin.files {
                     let dest_path = fish_config_dir.join(file.dir.as_str()).join(&file.name);
-                    if dest_path.exists() {
-                        let to_delete = dest_path.clone();
-                        let _ = tokio::task::spawn_blocking(move || fs::remove_file(&to_delete))
-                            .await
-                            .map_err(|e| anyhow::anyhow!(e))
-                            .and_then(|res| res.map_err(|e| anyhow::anyhow!(e)));
+                    let to_delete = dest_path.clone();
+                    let removed = tokio::task::spawn_blocking(move || {
+                        utils::remove_file_if_exists(&to_delete)
+                    })
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e))??;
+                    if removed {
+                        info!("   - {}", dest_path.display());
                     }
                 }
 
@@ -846,6 +844,38 @@ mod tests {
             fs::metadata(test_env.fish_config_dir.join("functions/used.fish")).is_ok(),
             "Used plugin file should still exist"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prune_parallel_preserves_lock_when_plugin_file_removal_fails() {
+        let _jobs = JobsGuard::set(1);
+        let mut test_env = TestEnvironmentSetup::new();
+        let test_data = TestDataBuilder::new().build();
+        let unused_repo = test_data.unused_plugin.repo.clone();
+        test_env.setup_config(config::Config {
+            plugins: Some(vec![test_data.used_plugin_spec]),
+        });
+        test_env.setup_lock_file(LockFile {
+            version: 1,
+            plugins: vec![test_data.used_plugin, test_data.unused_plugin],
+        });
+
+        let blocked_path = test_env
+            .fish_config_dir
+            .join(TargetDir::Functions.as_str())
+            .join("unused.fish");
+        std::fs::create_dir_all(&blocked_path).unwrap();
+
+        let mut ctx = test_env.create_context();
+        let err = prune_parallel_with_confirm(true, true, &mut ctx, || Ok(true))
+            .await
+            .expect_err("file removal failure should abort prune");
+        let err_text = format!("{:#}", err);
+        assert!(err_text.contains("Failed to remove"), "{err_text}");
+
+        let saved = lock_file::load(ctx.lock_file_path).unwrap();
+        assert!(saved.get_plugin_by_repo(&unused_repo).is_some());
+        assert!(blocked_path.is_dir());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/cmd/prune.rs
+++ b/src/cmd/prune.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use console::Emoji;
 use futures::{StreamExt, stream};
-use std::{fs, io, path};
+use std::{io, path};
 use tracing::{info, warn};
 
 struct PruneContext<'a> {
@@ -164,12 +164,10 @@ where
             info!("   - {}", dest_path.display());
         }
 
-        if repo_path.exists() {
-            fs::remove_dir_all(&repo_path)?;
-        }
         ctx.lock_file.remove_plugin(&plugin.source);
         ctx.lock_file.save(ctx.lock_file_path)?;
         staged_removals.commit();
+        utils::remove_dir_all_best_effort(&repo_path);
     }
     info!(
         "\n{}All uninstalled plugins have been pruned successfully!",
@@ -253,9 +251,10 @@ where
                                 fish_config_dir.join(file.dir.as_str()).join(&file.name);
                             info!("   - {}", dest_path.display());
                         }
-                        return Ok::<Option<(String, utils::StagedFileRemovals)>, anyhow::Error>(
-                            None,
-                        );
+                        return Ok::<
+                            Option<(String, utils::StagedFileRemovals, path::PathBuf)>,
+                            anyhow::Error,
+                        >(None);
                     }
                 }
 
@@ -272,22 +271,20 @@ where
                     info!("   - {}", dest_path.display());
                 }
 
-                if repo_path.exists() {
-                    tokio::task::spawn_blocking(move || fs::remove_dir_all(&repo_path)).await??;
-                }
-
-                Ok(Some((plugin.source.clone(), staged_removals)))
+                Ok(Some((plugin.source.clone(), staged_removals, repo_path)))
             }
         })
         .buffer_unordered(jobs);
 
     let mut sources_to_remove: Vec<String> = Vec::new();
     let mut staged_removals = Vec::new();
+    let mut repo_paths = Vec::new();
     futures::pin_mut!(tasks);
     while let Some(res) = tasks.next().await {
-        if let Some((source, removals)) = res? {
+        if let Some((source, removals, repo_path)) = res? {
             sources_to_remove.push(source);
             staged_removals.push(removals);
+            repo_paths.push(repo_path);
         }
     }
 
@@ -298,6 +295,9 @@ where
         ctx.lock_file.save(ctx.lock_file_path)?;
         for removals in staged_removals {
             removals.commit();
+        }
+        for repo_path in repo_paths {
+            utils::remove_dir_all_best_effort(&repo_path);
         }
     }
 
@@ -425,7 +425,7 @@ impl Drop for ConfirmInputGuard {
 
 #[cfg(test)]
 mod tests {
-    use std::{ffi::OsString, future::Future, os::unix::fs::PermissionsExt, vec};
+    use std::{ffi::OsString, fs, future::Future, os::unix::fs::PermissionsExt, vec};
 
     use super::*;
     use crate::tests_support::log::{capture_logs, env_lock};
@@ -845,6 +845,50 @@ mod tests {
     }
 
     #[test]
+    fn prune_preserves_repo_when_lock_save_fails() {
+        let mut test_env = TestEnvironmentSetup::new();
+        let test_data = TestDataBuilder::new().build();
+        let unused_repo = test_data.unused_plugin.repo.clone();
+        test_env.setup_config(config::Config {
+            plugins: Some(vec![test_data.used_plugin_spec]),
+        });
+        test_env.setup_lock_file(LockFile {
+            version: 1,
+            plugins: vec![test_data.used_plugin, test_data.unused_plugin],
+        });
+        test_env.setup_data_repo(test_env.lock_file.as_ref().unwrap().get_plugin_repos());
+        test_env.setup_fish_config();
+
+        let plugin_file = test_env
+            .fish_config_dir
+            .join(TargetDir::Functions.as_str())
+            .join("unused.fish");
+        let repo_path = test_env.data_dir.join(unused_repo.as_str());
+        let mut ctx = test_env.create_context();
+        let original_perms = std::fs::metadata(ctx.lock_file_path).unwrap().permissions();
+        let mut read_only_perms = original_perms.clone();
+        read_only_perms.set_mode(0o400);
+        std::fs::set_permissions(ctx.lock_file_path, read_only_perms).unwrap();
+
+        let err = prune(true, false, || Ok(false), &mut ctx)
+            .expect_err("lock save failure should abort prune");
+        std::fs::set_permissions(ctx.lock_file_path, original_perms).unwrap();
+        let err_text = format!("{:#}", err);
+        assert!(err_text.contains("Permission denied"), "{err_text}");
+
+        let saved = lock_file::load(ctx.lock_file_path).unwrap();
+        assert!(saved.get_plugin_by_repo(&unused_repo).is_some());
+        assert!(
+            repo_path.exists(),
+            "unused repo directory should remain when lock save fails"
+        );
+        assert!(
+            plugin_file.exists(),
+            "staged plugin files should be restored when lock save fails"
+        );
+    }
+
+    #[test]
     fn test_prune_empty_config_missing_data_dir_without_force() {
         let mut test_env = TestEnvironmentSetup::new();
         let test_data = TestDataBuilder::new().build();
@@ -946,6 +990,52 @@ mod tests {
         assert!(
             fs::metadata(ctx.data_dir.join("owner/unused-repo")).is_ok(),
             "Unused repo directory should remain when file deletion is rejected"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prune_parallel_preserves_repo_when_lock_save_fails() {
+        let _jobs = JobsGuard::set(1);
+        let mut test_env = TestEnvironmentSetup::new();
+        let test_data = TestDataBuilder::new().build();
+        let unused_repo = test_data.unused_plugin.repo.clone();
+        test_env.setup_config(config::Config {
+            plugins: Some(vec![test_data.used_plugin_spec]),
+        });
+        test_env.setup_lock_file(LockFile {
+            version: 1,
+            plugins: vec![test_data.used_plugin, test_data.unused_plugin],
+        });
+        test_env.setup_data_repo(test_env.lock_file.as_ref().unwrap().get_plugin_repos());
+        test_env.setup_fish_config();
+
+        let plugin_file = test_env
+            .fish_config_dir
+            .join(TargetDir::Functions.as_str())
+            .join("unused.fish");
+        let repo_path = test_env.data_dir.join(unused_repo.as_str());
+        let mut ctx = test_env.create_context();
+        let original_perms = std::fs::metadata(ctx.lock_file_path).unwrap().permissions();
+        let mut read_only_perms = original_perms.clone();
+        read_only_perms.set_mode(0o400);
+        std::fs::set_permissions(ctx.lock_file_path, read_only_perms).unwrap();
+
+        let err = prune_parallel_with_confirm(true, true, &mut ctx, || Ok(true))
+            .await
+            .expect_err("lock save failure should abort prune");
+        std::fs::set_permissions(ctx.lock_file_path, original_perms).unwrap();
+        let err_text = format!("{:#}", err);
+        assert!(err_text.contains("Permission denied"), "{err_text}");
+
+        let saved = lock_file::load(ctx.lock_file_path).unwrap();
+        assert!(saved.get_plugin_by_repo(&unused_repo).is_some());
+        assert!(
+            repo_path.exists(),
+            "unused repo directory should remain when lock save fails"
+        );
+        assert!(
+            plugin_file.exists(),
+            "staged plugin files should be restored when lock save fails"
         );
     }
 

--- a/src/cmd/prune.rs
+++ b/src/cmd/prune.rs
@@ -259,12 +259,14 @@ where
                     }
                 }
 
-                let staged_file_removals = tokio::task::spawn_blocking(move || {
-                    utils::stage_files_for_removal(&file_paths)
-                })
-                .await??;
-                let staged_repo_removals =
-                    utils::stage_dirs_for_removal(std::slice::from_ref(&repo_path))?;
+                let (staged_file_removals, staged_repo_removals) =
+                    tokio::task::spawn_blocking(move || {
+                        let staged_file_removals = utils::stage_files_for_removal(&file_paths)?;
+                        let staged_repo_removals =
+                            utils::stage_dirs_for_removal(std::slice::from_ref(&repo_path))?;
+                        Ok::<_, anyhow::Error>((staged_file_removals, staged_repo_removals))
+                    })
+                    .await??;
 
                 info!(
                     "{}Removing plugin files based on pez-lock.toml:",

--- a/src/cmd/uninstall.rs
+++ b/src/cmd/uninstall.rs
@@ -125,16 +125,12 @@ pub(crate) fn uninstall(plugin_repo: &PluginRepo, force: bool) -> anyhow::Result
                 "{}Removing plugin files based on pez-lock.toml:",
                 Emoji("🗑️  ", ""),
             );
-            locked.files.iter().for_each(|file| {
-                let dest_path = config_dir.join(file.dir.as_str()).join(&file.name);
-                if dest_path.exists() {
-                    let path_display = dest_path.display();
-                    info!("   - {}", path_display);
-                    if let Err(e) = fs::remove_file(&dest_path) {
-                        warn!("Failed to remove {}: {:?}", path_display, e);
-                    }
+            for file in &locked.files {
+                let dest_path = file.get_path(&config_dir);
+                if utils::remove_file_if_exists(&dest_path)? {
+                    info!("   - {}", dest_path.display());
                 }
-            });
+            }
             lock_file.remove_plugin(&locked.source);
             lock_file.save(&lock_file_path)?;
 
@@ -545,6 +541,72 @@ owner/plugin-a
                 std::env::remove_var("NO_COLOR")
             }
         }
+    }
+
+    #[test]
+    fn uninstall_preserves_state_when_plugin_file_removal_fails() {
+        let _lock = crate::tests_support::log::env_lock().lock().unwrap();
+        let mut env = TestEnvironmentSetup::new();
+        let _override = EnvOverride::new(&["__fish_config_dir", "PEZ_CONFIG_DIR", "PEZ_DATA_DIR"]);
+        unsafe {
+            std::env::set_var("__fish_config_dir", &env.fish_config_dir);
+            std::env::set_var("PEZ_CONFIG_DIR", &env.config_dir);
+            std::env::set_var("PEZ_DATA_DIR", &env.data_dir);
+        }
+
+        let repo = PluginRepo {
+            host: None,
+            owner: "owner".into(),
+            repo: "blocked".into(),
+        };
+        env.setup_config(config::Config {
+            plugins: Some(vec![config::PluginSpec {
+                name: None,
+                source: config::PluginSource::Repo {
+                    repo: repo.clone(),
+                    version: None,
+                    branch: None,
+                    tag: None,
+                    commit: None,
+                },
+            }]),
+        });
+        env.setup_lock_file(LockFile {
+            version: 1,
+            plugins: vec![crate::lock_file::Plugin {
+                name: "blocked".into(),
+                repo: repo.clone(),
+                source: repo.default_remote_source(),
+                commit_sha: "abc1234".into(),
+                files: vec![PluginFile {
+                    dir: TargetDir::Functions,
+                    name: "blocked.fish".into(),
+                }],
+            }],
+        });
+
+        let blocked_path = env
+            .fish_config_dir
+            .join(TargetDir::Functions.as_str())
+            .join("blocked.fish");
+        std::fs::create_dir_all(&blocked_path).unwrap();
+
+        let err = uninstall(&repo, true).expect_err("file removal failure should abort uninstall");
+        let err_text = format!("{:#}", err);
+        assert!(err_text.contains("Failed to remove"), "{err_text}");
+
+        let saved_lock = lock_file::load(&env.lock_file_path).unwrap();
+        assert!(saved_lock.get_plugin_by_repo(&repo).is_some());
+
+        let saved_config = config::load(&env.config_path).unwrap();
+        assert!(
+            saved_config.plugins.unwrap_or_default().iter().any(|p| p
+                .get_plugin_repo()
+                .ok()
+                .as_ref()
+                == Some(&repo))
+        );
+        assert!(blocked_path.is_dir());
     }
 
     #[test]

--- a/src/cmd/uninstall.rs
+++ b/src/cmd/uninstall.rs
@@ -126,12 +126,25 @@ pub(crate) fn uninstall(plugin_repo: &PluginRepo, force: bool) -> anyhow::Result
                 info!("   - {}", dest_path.display());
             }
 
-            lock_file.remove_plugin(&locked.source);
-            lock_file.save(&lock_file_path)?;
-
-            if let Some(ref mut plugin_specs) = config.plugins {
+            let original_config = config.clone();
+            let config_saved = if let Some(ref mut plugin_specs) = config.plugins {
                 plugin_specs.retain(|p| p.get_plugin_repo().map_or(true, |r| r != *plugin_repo));
                 config.save(&config_path)?;
+                true
+            } else {
+                false
+            };
+
+            lock_file.remove_plugin(&locked.source);
+            if let Err(err) = lock_file.save(&lock_file_path) {
+                if config_saved && let Err(restore_err) = original_config.save(&config_path) {
+                    warn!(
+                        "Failed to restore config {} after failed uninstall: {:?}",
+                        config_path.display(),
+                        restore_err
+                    );
+                }
+                return Err(err);
             }
 
             staged_removals.commit();
@@ -725,6 +738,97 @@ owner/plugin-a
         );
         let saved_lock = lock_file::load(&env.lock_file_path).unwrap();
         assert!(saved_lock.get_plugin_by_repo(&repo).is_some());
+        let saved_config = config::load(&env.config_path).unwrap();
+        assert!(
+            saved_config.plugins.unwrap_or_default().iter().any(|p| p
+                .get_plugin_repo()
+                .ok()
+                .as_ref()
+                == Some(&repo))
+        );
+    }
+
+    #[test]
+    fn uninstall_preserves_state_when_config_save_fails() {
+        let _lock = crate::tests_support::log::env_lock().lock().unwrap();
+        let mut env = TestEnvironmentSetup::new();
+        let _override = EnvOverride::new(&[
+            "PEZ_SUPPRESS_EMIT",
+            "__fish_config_dir",
+            "PEZ_CONFIG_DIR",
+            "PEZ_DATA_DIR",
+        ]);
+        unsafe {
+            std::env::set_var("PEZ_SUPPRESS_EMIT", "1");
+            std::env::set_var("__fish_config_dir", &env.fish_config_dir);
+            std::env::set_var("PEZ_CONFIG_DIR", &env.config_dir);
+            std::env::set_var("PEZ_DATA_DIR", &env.data_dir);
+        }
+
+        let repo = PluginRepo {
+            host: None,
+            owner: "owner".into(),
+            repo: "blocked".into(),
+        };
+        env.setup_config(config::Config {
+            plugins: Some(vec![config::PluginSpec {
+                name: None,
+                source: config::PluginSource::Repo {
+                    repo: repo.clone(),
+                    version: None,
+                    branch: None,
+                    tag: None,
+                    commit: None,
+                },
+            }]),
+        });
+        env.setup_lock_file(LockFile {
+            version: 1,
+            plugins: vec![crate::lock_file::Plugin {
+                name: "blocked".into(),
+                repo: repo.clone(),
+                source: repo.default_remote_source(),
+                commit_sha: "abc1234".into(),
+                files: vec![PluginFile {
+                    dir: TargetDir::ConfD,
+                    name: "blocked.fish".into(),
+                }],
+            }],
+        });
+        env.setup_data_repo(vec![repo.clone()]);
+        env.setup_fish_config();
+        let repo_path = env.data_dir.join(repo.as_str());
+        let plugin_file = env
+            .fish_config_dir
+            .join(TargetDir::ConfD.as_str())
+            .join("blocked.fish");
+        let original_perms = std::fs::metadata(&env.config_path).unwrap().permissions();
+        let mut read_only_perms = original_perms.clone();
+        read_only_perms.set_mode(0o400);
+        std::fs::set_permissions(&env.config_path, read_only_perms).unwrap();
+
+        let err = uninstall(&repo, true).expect_err("config save failure should abort uninstall");
+        std::fs::set_permissions(&env.config_path, original_perms).unwrap();
+        let err_text = format!("{:#}", err);
+        assert!(err_text.contains("Permission denied"), "{err_text}");
+        assert!(
+            repo_path.exists(),
+            "repo directory should remain when config save fails"
+        );
+        assert!(
+            plugin_file.exists(),
+            "staged plugin files should be restored when config save fails"
+        );
+        let saved_lock = lock_file::load(&env.lock_file_path).unwrap();
+        assert!(saved_lock.get_plugin_by_repo(&repo).is_some());
+        let saved_config = config::load(&env.config_path).unwrap();
+        assert!(
+            saved_config.plugins.unwrap_or_default().iter().any(|p| p
+                .get_plugin_repo()
+                .ok()
+                .as_ref()
+                == Some(&repo))
+        );
     }
 
     #[test]

--- a/src/cmd/uninstall.rs
+++ b/src/cmd/uninstall.rs
@@ -116,13 +116,15 @@ pub(crate) fn uninstall(plugin_repo: &PluginRepo, force: bool) -> anyhow::Result
                 }
             }
 
-            let staged_removals = utils::stage_files_for_removal(&file_paths)?;
+            let staged_file_removals = utils::stage_files_for_removal(&file_paths)?;
+            let staged_repo_removals =
+                utils::stage_dirs_for_removal(std::slice::from_ref(&repo_path))?;
 
             info!(
                 "{}Removing plugin files based on pez-lock.toml:",
                 Emoji("🗑️  ", ""),
             );
-            for dest_path in staged_removals.removed_paths() {
+            for dest_path in staged_file_removals.removed_paths() {
                 info!("   - {}", dest_path.display());
             }
 
@@ -147,8 +149,8 @@ pub(crate) fn uninstall(plugin_repo: &PluginRepo, force: bool) -> anyhow::Result
                 return Err(err);
             }
 
-            staged_removals.commit();
-            utils::remove_dir_all_if_exists(&repo_path)?;
+            staged_file_removals.commit();
+            staged_repo_removals.commit();
             locked
                 .files
                 .iter()
@@ -832,7 +834,7 @@ owner/plugin-a
     }
 
     #[test]
-    fn uninstall_reports_repo_cleanup_failure() {
+    fn uninstall_removes_original_repo_path_when_staged_cleanup_fails() {
         let _lock = crate::tests_support::log::env_lock().lock().unwrap();
         let mut env = TestEnvironmentSetup::new();
         let _override = EnvOverride::new(&[
@@ -888,17 +890,30 @@ owner/plugin-a
         restricted_perms.set_mode(0o500);
         std::fs::set_permissions(&repo_path, restricted_perms).unwrap();
 
-        let err = uninstall(&repo, true).expect_err("repo cleanup failure should be reported");
-        std::fs::set_permissions(&repo_path, original_perms).unwrap();
-        let err_text = format!("{:#}", err);
+        let result = uninstall(&repo, true);
+        let owner_dir = repo_path.parent().unwrap();
+        if repo_path.exists() {
+            std::fs::set_permissions(&repo_path, original_perms.clone()).unwrap();
+        }
+        for entry in std::fs::read_dir(owner_dir).unwrap() {
+            let entry = entry.unwrap();
+            if entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".pez-removing-")
+            {
+                std::fs::set_permissions(entry.path(), original_perms.clone()).unwrap();
+                let _ = std::fs::remove_dir_all(entry.path());
+            }
+        }
+
+        result.expect("staged repo cleanup should not fail uninstall after state is persisted");
         assert!(
-            err_text.contains("Failed to remove directory"),
-            "{err_text}"
+            !repo_path.exists(),
+            "original repo directory should not remain after uninstall"
         );
-        assert!(
-            repo_path.exists(),
-            "repo directory should remain when cleanup fails"
-        );
+        let lock = lock_file::load(&env.lock_file_path).unwrap();
+        assert!(lock.get_plugin_by_repo(&repo).is_none());
     }
 
     #[test]

--- a/src/cmd/uninstall.rs
+++ b/src/cmd/uninstall.rs
@@ -2,7 +2,7 @@ use crate::{cli::UninstallArgs, models::PluginRepo, models::TargetDir, utils};
 
 use console::Emoji;
 use futures::{StreamExt, stream};
-use std::{collections::HashSet, fs, io};
+use std::{collections::HashSet, io};
 use tracing::{error, info, warn};
 
 pub(crate) async fn run(args: &UninstallArgs) -> anyhow::Result<()> {
@@ -126,9 +126,6 @@ pub(crate) fn uninstall(plugin_repo: &PluginRepo, force: bool) -> anyhow::Result
                 info!("   - {}", dest_path.display());
             }
 
-            if repo_path.exists() {
-                fs::remove_dir_all(&repo_path)?;
-            }
             lock_file.remove_plugin(&locked.source);
             lock_file.save(&lock_file_path)?;
 
@@ -138,6 +135,7 @@ pub(crate) fn uninstall(plugin_repo: &PluginRepo, force: bool) -> anyhow::Result
             }
 
             staged_removals.commit();
+            utils::remove_dir_all_best_effort(&repo_path);
             locked
                 .files
                 .iter()
@@ -650,6 +648,83 @@ owner/plugin-a
             !log_path.exists(),
             "uninstall event should not be emitted when deletion is rejected"
         );
+    }
+
+    #[test]
+    fn uninstall_preserves_repo_when_lock_save_fails() {
+        let _lock = crate::tests_support::log::env_lock().lock().unwrap();
+        let mut env = TestEnvironmentSetup::new();
+        let _override = EnvOverride::new(&[
+            "PEZ_SUPPRESS_EMIT",
+            "__fish_config_dir",
+            "PEZ_CONFIG_DIR",
+            "PEZ_DATA_DIR",
+        ]);
+        unsafe {
+            std::env::set_var("PEZ_SUPPRESS_EMIT", "1");
+            std::env::set_var("__fish_config_dir", &env.fish_config_dir);
+            std::env::set_var("PEZ_CONFIG_DIR", &env.config_dir);
+            std::env::set_var("PEZ_DATA_DIR", &env.data_dir);
+        }
+
+        let repo = PluginRepo {
+            host: None,
+            owner: "owner".into(),
+            repo: "blocked".into(),
+        };
+        env.setup_config(config::Config {
+            plugins: Some(vec![config::PluginSpec {
+                name: None,
+                source: config::PluginSource::Repo {
+                    repo: repo.clone(),
+                    version: None,
+                    branch: None,
+                    tag: None,
+                    commit: None,
+                },
+            }]),
+        });
+        env.setup_lock_file(LockFile {
+            version: 1,
+            plugins: vec![crate::lock_file::Plugin {
+                name: "blocked".into(),
+                repo: repo.clone(),
+                source: repo.default_remote_source(),
+                commit_sha: "abc1234".into(),
+                files: vec![PluginFile {
+                    dir: TargetDir::ConfD,
+                    name: "blocked.fish".into(),
+                }],
+            }],
+        });
+        env.setup_data_repo(vec![repo.clone()]);
+        env.setup_fish_config();
+        let repo_path = env.data_dir.join(repo.as_str());
+        let plugin_file = env
+            .fish_config_dir
+            .join(TargetDir::ConfD.as_str())
+            .join("blocked.fish");
+        let original_perms = std::fs::metadata(&env.lock_file_path)
+            .unwrap()
+            .permissions();
+        let mut read_only_perms = original_perms.clone();
+        read_only_perms.set_mode(0o400);
+        std::fs::set_permissions(&env.lock_file_path, read_only_perms).unwrap();
+
+        let err = uninstall(&repo, true).expect_err("lock save failure should abort uninstall");
+        std::fs::set_permissions(&env.lock_file_path, original_perms).unwrap();
+        let err_text = format!("{:#}", err);
+        assert!(err_text.contains("Permission denied"), "{err_text}");
+        assert!(
+            repo_path.exists(),
+            "repo directory should remain when lock save fails"
+        );
+        assert!(
+            plugin_file.exists(),
+            "staged plugin files should be restored when lock save fails"
+        );
+        let saved_lock = lock_file::load(&env.lock_file_path).unwrap();
+        assert!(saved_lock.get_plugin_by_repo(&repo).is_some());
     }
 
     #[test]

--- a/src/cmd/uninstall.rs
+++ b/src/cmd/uninstall.rs
@@ -87,17 +87,13 @@ pub(crate) fn uninstall(plugin_repo: &PluginRepo, force: bool) -> anyhow::Result
     match lock_file.get_plugin_by_repo(plugin_repo) {
         Some(locked_plugin) => {
             let locked = locked_plugin.clone();
-            locked
+            let file_paths: Vec<_> = locked
                 .files
                 .iter()
-                .filter(|f| f.dir == TargetDir::ConfD)
-                .for_each(|f| {
-                    let _ = utils::emit_event(&f.name, &utils::Event::Uninstall);
-                });
+                .map(|file| file.get_path(&config_dir))
+                .collect();
 
-            if repo_path.exists() {
-                fs::remove_dir_all(&repo_path)?;
-            } else {
+            if !repo_path.exists() {
                 let path_display = repo_path.display();
                 warn!(
                     "{} {} Repository directory at {} does not exist.",
@@ -110,10 +106,9 @@ pub(crate) fn uninstall(plugin_repo: &PluginRepo, force: bool) -> anyhow::Result
                         "{}Detected plugin files based on pez-lock.toml:",
                         Emoji("📄 ", ""),
                     );
-                    locked.files.iter().for_each(|file| {
-                        let dest_path = config_dir.join(file.dir.as_str()).join(&file.name);
-                        info!("   - {}", dest_path.display());
-                    });
+                    file_paths
+                        .iter()
+                        .for_each(|dest_path| info!("   - {}", dest_path.display()));
                     error!("If you want to remove these files, use the --force flag.");
                     anyhow::bail!(
                         "Repository directory does not exist. Use --force to remove files listed in lock file"
@@ -121,13 +116,17 @@ pub(crate) fn uninstall(plugin_repo: &PluginRepo, force: bool) -> anyhow::Result
                 }
             }
 
+            utils::ensure_files_removable(&file_paths)?;
+            if repo_path.exists() {
+                fs::remove_dir_all(&repo_path)?;
+            }
+
             info!(
                 "{}Removing plugin files based on pez-lock.toml:",
                 Emoji("🗑️  ", ""),
             );
-            for file in &locked.files {
-                let dest_path = file.get_path(&config_dir);
-                if utils::remove_file_if_exists(&dest_path)? {
+            for dest_path in &file_paths {
+                if utils::remove_file_if_exists(dest_path)? {
                     info!("   - {}", dest_path.display());
                 }
             }
@@ -138,6 +137,14 @@ pub(crate) fn uninstall(plugin_repo: &PluginRepo, force: bool) -> anyhow::Result
                 plugin_specs.retain(|p| p.get_plugin_repo().map_or(true, |r| r != *plugin_repo));
                 config.save(&config_path)?;
             }
+
+            locked
+                .files
+                .iter()
+                .filter(|f| f.dir == TargetDir::ConfD)
+                .for_each(|f| {
+                    let _ = utils::emit_event(&f.name, &utils::Event::Uninstall);
+                });
         }
         None => {
             error!(
@@ -547,8 +554,28 @@ owner/plugin-a
     fn uninstall_preserves_state_when_plugin_file_removal_fails() {
         let _lock = crate::tests_support::log::env_lock().lock().unwrap();
         let mut env = TestEnvironmentSetup::new();
-        let _override = EnvOverride::new(&["__fish_config_dir", "PEZ_CONFIG_DIR", "PEZ_DATA_DIR"]);
+        let _override = EnvOverride::new(&[
+            "PATH",
+            "PEZ_SUPPRESS_EMIT",
+            "__fish_config_dir",
+            "PEZ_CONFIG_DIR",
+            "PEZ_DATA_DIR",
+        ]);
+        let temp_dir = tempfile::tempdir().unwrap();
+        let bin_dir = temp_dir.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let log_path = temp_dir.path().join("fish.log");
+        let fish_path = bin_dir.join("fish");
+        let script = format!("#!/bin/sh\n\necho \"$@\" >> \"{}\"\n", log_path.display());
+        std::fs::write(&fish_path, script).unwrap();
+        let mut perms = std::fs::metadata(&fish_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fish_path, perms).unwrap();
+
+        let existing_path = std::env::var("PATH").unwrap_or_default();
         unsafe {
+            std::env::set_var("PATH", format!("{}:{}", bin_dir.display(), existing_path));
+            std::env::remove_var("PEZ_SUPPRESS_EMIT");
             std::env::set_var("__fish_config_dir", &env.fish_config_dir);
             std::env::set_var("PEZ_CONFIG_DIR", &env.config_dir);
             std::env::set_var("PEZ_DATA_DIR", &env.data_dir);
@@ -579,7 +606,7 @@ owner/plugin-a
                 source: repo.default_remote_source(),
                 commit_sha: "abc1234".into(),
                 files: vec![PluginFile {
-                    dir: TargetDir::Functions,
+                    dir: TargetDir::ConfD,
                     name: "blocked.fish".into(),
                 }],
             }],
@@ -587,7 +614,7 @@ owner/plugin-a
 
         let blocked_path = env
             .fish_config_dir
-            .join(TargetDir::Functions.as_str())
+            .join(TargetDir::ConfD.as_str())
             .join("blocked.fish");
         std::fs::create_dir_all(&blocked_path).unwrap();
 
@@ -607,6 +634,10 @@ owner/plugin-a
                 == Some(&repo))
         );
         assert!(blocked_path.is_dir());
+        assert!(
+            !log_path.exists(),
+            "uninstall event should not be emitted when deletion is rejected"
+        );
     }
 
     #[test]

--- a/src/cmd/uninstall.rs
+++ b/src/cmd/uninstall.rs
@@ -116,19 +116,18 @@ pub(crate) fn uninstall(plugin_repo: &PluginRepo, force: bool) -> anyhow::Result
                 }
             }
 
-            utils::ensure_files_removable(&file_paths)?;
-            if repo_path.exists() {
-                fs::remove_dir_all(&repo_path)?;
-            }
+            let staged_removals = utils::stage_files_for_removal(&file_paths)?;
 
             info!(
                 "{}Removing plugin files based on pez-lock.toml:",
                 Emoji("🗑️  ", ""),
             );
-            for dest_path in &file_paths {
-                if utils::remove_file_if_exists(dest_path)? {
-                    info!("   - {}", dest_path.display());
-                }
+            for dest_path in staged_removals.removed_paths() {
+                info!("   - {}", dest_path.display());
+            }
+
+            if repo_path.exists() {
+                fs::remove_dir_all(&repo_path)?;
             }
             lock_file.remove_plugin(&locked.source);
             lock_file.save(&lock_file_path)?;
@@ -138,6 +137,7 @@ pub(crate) fn uninstall(plugin_repo: &PluginRepo, force: bool) -> anyhow::Result
                 config.save(&config_path)?;
             }
 
+            staged_removals.commit();
             locked
                 .files
                 .iter()
@@ -611,14 +611,22 @@ owner/plugin-a
                 }],
             }],
         });
+        env.setup_data_repo(vec![repo.clone()]);
 
         let blocked_path = env
             .fish_config_dir
             .join(TargetDir::ConfD.as_str())
             .join("blocked.fish");
-        std::fs::create_dir_all(&blocked_path).unwrap();
+        std::fs::create_dir_all(blocked_path.parent().unwrap()).unwrap();
+        std::fs::write(&blocked_path, "echo blocked\n").unwrap();
+        let conf_d_dir = blocked_path.parent().unwrap();
+        let original_perms = std::fs::metadata(conf_d_dir).unwrap().permissions();
+        let mut read_only_perms = original_perms.clone();
+        read_only_perms.set_mode(0o500);
+        std::fs::set_permissions(conf_d_dir, read_only_perms).unwrap();
 
         let err = uninstall(&repo, true).expect_err("file removal failure should abort uninstall");
+        std::fs::set_permissions(conf_d_dir, original_perms).unwrap();
         let err_text = format!("{:#}", err);
         assert!(err_text.contains("Failed to remove"), "{err_text}");
 
@@ -633,7 +641,11 @@ owner/plugin-a
                 .as_ref()
                 == Some(&repo))
         );
-        assert!(blocked_path.is_dir());
+        assert!(blocked_path.is_file());
+        assert!(
+            env.data_dir.join(repo.as_str()).exists(),
+            "repo directory should remain when file deletion fails"
+        );
         assert!(
             !log_path.exists(),
             "uninstall event should not be emitted when deletion is rejected"

--- a/src/cmd/uninstall.rs
+++ b/src/cmd/uninstall.rs
@@ -148,7 +148,7 @@ pub(crate) fn uninstall(plugin_repo: &PluginRepo, force: bool) -> anyhow::Result
             }
 
             staged_removals.commit();
-            utils::remove_dir_all_best_effort(&repo_path);
+            utils::remove_dir_all_if_exists(&repo_path)?;
             locked
                 .files
                 .iter()
@@ -828,6 +828,76 @@ owner/plugin-a
                 .ok()
                 .as_ref()
                 == Some(&repo))
+        );
+    }
+
+    #[test]
+    fn uninstall_reports_repo_cleanup_failure() {
+        let _lock = crate::tests_support::log::env_lock().lock().unwrap();
+        let mut env = TestEnvironmentSetup::new();
+        let _override = EnvOverride::new(&[
+            "PEZ_SUPPRESS_EMIT",
+            "__fish_config_dir",
+            "PEZ_CONFIG_DIR",
+            "PEZ_DATA_DIR",
+        ]);
+        unsafe {
+            std::env::set_var("PEZ_SUPPRESS_EMIT", "1");
+            std::env::set_var("__fish_config_dir", &env.fish_config_dir);
+            std::env::set_var("PEZ_CONFIG_DIR", &env.config_dir);
+            std::env::set_var("PEZ_DATA_DIR", &env.data_dir);
+        }
+
+        let repo = PluginRepo {
+            host: None,
+            owner: "owner".into(),
+            repo: "blocked".into(),
+        };
+        env.setup_config(config::Config {
+            plugins: Some(vec![config::PluginSpec {
+                name: None,
+                source: config::PluginSource::Repo {
+                    repo: repo.clone(),
+                    version: None,
+                    branch: None,
+                    tag: None,
+                    commit: None,
+                },
+            }]),
+        });
+        env.setup_lock_file(LockFile {
+            version: 1,
+            plugins: vec![crate::lock_file::Plugin {
+                name: "blocked".into(),
+                repo: repo.clone(),
+                source: repo.default_remote_source(),
+                commit_sha: "abc1234".into(),
+                files: vec![PluginFile {
+                    dir: TargetDir::ConfD,
+                    name: "blocked.fish".into(),
+                }],
+            }],
+        });
+        env.setup_data_repo(vec![repo.clone()]);
+        env.setup_fish_config();
+        let repo_path = env.data_dir.join(repo.as_str());
+        let repo_file = repo_path.join("repo-file");
+        std::fs::write(&repo_file, "repo data").unwrap();
+        let original_perms = std::fs::metadata(&repo_path).unwrap().permissions();
+        let mut restricted_perms = original_perms.clone();
+        restricted_perms.set_mode(0o500);
+        std::fs::set_permissions(&repo_path, restricted_perms).unwrap();
+
+        let err = uninstall(&repo, true).expect_err("repo cleanup failure should be reported");
+        std::fs::set_permissions(&repo_path, original_perms).unwrap();
+        let err_text = format!("{:#}", err);
+        assert!(
+            err_text.contains("Failed to remove directory"),
+            "{err_text}"
+        );
+        assert!(
+            repo_path.exists(),
+            "repo directory should remain when cleanup fails"
         );
     }
 

--- a/src/cmd/upgrade.rs
+++ b/src/cmd/upgrade.rs
@@ -9,7 +9,6 @@ use crate::{
 use anyhow::Context;
 use console::Emoji;
 use futures::{StreamExt, stream};
-use std::fs;
 use tracing::{error, info, warn};
 
 pub(crate) async fn run(args: &UpgradeArgs) -> anyhow::Result<()> {
@@ -149,14 +148,12 @@ fn upgrade_plugin(plugin_repo: &PluginRepo) -> anyhow::Result<()> {
 
                 git::checkout_commit(&repo, &latest_remote_commit)?;
 
-                lock_file_plugin.files.iter().for_each(|file| {
-                    let dest_path = config_dir.join(file.dir.as_str()).join(&file.name);
-                    if dest_path.exists()
-                        && let Err(e) = fs::remove_file(&dest_path)
-                    {
-                        warn!("Failed to remove {}: {:?}", dest_path.display(), e);
+                for file in &lock_file_plugin.files {
+                    let dest_path = file.get_path(&config_dir);
+                    if utils::remove_file_if_exists(&dest_path)? {
+                        info!("   - {}", dest_path.display());
                     }
-                });
+                }
                 let mut updated_plugin = Plugin {
                     name: lock_file_plugin.name.to_string(),
                     repo: plugin_repo.clone(),
@@ -671,6 +668,63 @@ mod tests {
             .join(TargetDir::Functions.as_str())
             .join("beta.fish");
         assert!(!beta_path.exists());
+    }
+
+    #[test]
+    fn upgrade_plugin_preserves_lock_when_old_file_removal_fails() {
+        let _lock = crate::tests_support::log::env_lock().lock().unwrap();
+        crate::utils::clear_cli_jobs_override_for_tests();
+        let fixture = UpgradeFixture::new(false);
+        let _override = EnvOverride::new(&[
+            "PEZ_SUPPRESS_EMIT",
+            "__fish_config_dir",
+            "PEZ_CONFIG_DIR",
+            "PEZ_DATA_DIR",
+        ]);
+        unsafe {
+            std::env::set_var("PEZ_SUPPRESS_EMIT", "1");
+            std::env::set_var("__fish_config_dir", &fixture.env.fish_config_dir);
+            std::env::set_var("PEZ_CONFIG_DIR", &fixture.env.config_dir);
+            std::env::set_var("PEZ_DATA_DIR", &fixture.env.data_dir);
+        }
+
+        fixture.env.setup_fish_config();
+        let beta_path = fixture
+            .env
+            .fish_config_dir
+            .join(TargetDir::Functions.as_str())
+            .join("beta.fish");
+        std::fs::remove_file(&beta_path).unwrap();
+        std::fs::create_dir_all(&beta_path).unwrap();
+
+        let mut lock = lock_file::load(&fixture.env.lock_file_path).unwrap();
+        let locked = lock.get_plugin_by_repo(&fixture.repo).unwrap().clone();
+        let mut files = locked.files.clone();
+        files.swap(0, 1);
+        let mut reordered = locked;
+        reordered.files = files;
+        lock.update_plugin(reordered).unwrap();
+        lock.save(&fixture.env.lock_file_path).unwrap();
+
+        let repo_path = fixture.env.data_dir.join(fixture.repo.as_str());
+        let repo = git2::Repository::open(&repo_path).unwrap();
+        crate::git::checkout_commit(&repo, &fixture.first_commit).unwrap();
+
+        let err =
+            upgrade_plugin(&fixture.repo).expect_err("file removal failure should abort upgrade");
+        let err_text = format!("{:#}", err);
+        assert!(err_text.contains("Failed to remove"), "{err_text}");
+
+        let saved_lock = lock_file::load(&fixture.env.lock_file_path).unwrap();
+        let saved_plugin = saved_lock.get_plugin_by_repo(&fixture.repo).unwrap();
+        assert_eq!(saved_plugin.commit_sha, fixture.first_commit);
+        assert!(
+            saved_plugin
+                .files
+                .iter()
+                .any(|file| file.dir == TargetDir::Functions && file.name == "beta.fish")
+        );
+        assert!(beta_path.is_dir());
     }
 
     #[allow(clippy::await_holding_lock)]

--- a/src/cmd/upgrade.rs
+++ b/src/cmd/upgrade.rs
@@ -146,11 +146,16 @@ fn upgrade_plugin(plugin_repo: &PluginRepo) -> anyhow::Result<()> {
                     return Ok(());
                 }
 
+                let old_file_paths: Vec<_> = lock_file_plugin
+                    .files
+                    .iter()
+                    .map(|file| file.get_path(&config_dir))
+                    .collect();
+                utils::ensure_files_removable(&old_file_paths)?;
                 git::checkout_commit(&repo, &latest_remote_commit)?;
 
-                for file in &lock_file_plugin.files {
-                    let dest_path = file.get_path(&config_dir);
-                    if utils::remove_file_if_exists(&dest_path)? {
+                for dest_path in &old_file_paths {
+                    if utils::remove_file_if_exists(dest_path)? {
                         info!("   - {}", dest_path.display());
                     }
                 }
@@ -689,6 +694,12 @@ mod tests {
         }
 
         fixture.env.setup_fish_config();
+        let alpha_path = fixture
+            .env
+            .fish_config_dir
+            .join(TargetDir::ConfD.as_str())
+            .join("alpha.fish");
+        assert!(alpha_path.exists());
         let beta_path = fixture
             .env
             .fish_config_dir
@@ -696,15 +707,6 @@ mod tests {
             .join("beta.fish");
         std::fs::remove_file(&beta_path).unwrap();
         std::fs::create_dir_all(&beta_path).unwrap();
-
-        let mut lock = lock_file::load(&fixture.env.lock_file_path).unwrap();
-        let locked = lock.get_plugin_by_repo(&fixture.repo).unwrap().clone();
-        let mut files = locked.files.clone();
-        files.swap(0, 1);
-        let mut reordered = locked;
-        reordered.files = files;
-        lock.update_plugin(reordered).unwrap();
-        lock.save(&fixture.env.lock_file_path).unwrap();
 
         let repo_path = fixture.env.data_dir.join(fixture.repo.as_str());
         let repo = git2::Repository::open(&repo_path).unwrap();
@@ -724,7 +726,16 @@ mod tests {
                 .iter()
                 .any(|file| file.dir == TargetDir::Functions && file.name == "beta.fish")
         );
+        assert!(
+            alpha_path.exists(),
+            "earlier removable files should remain when another file is rejected"
+        );
         assert!(beta_path.is_dir());
+        assert_eq!(
+            crate::git::get_latest_commit_sha(&repo).unwrap(),
+            fixture.first_commit,
+            "repo checkout should not advance when old file removal is rejected"
+        );
     }
 
     #[allow(clippy::await_holding_lock)]

--- a/src/cmd/upgrade.rs
+++ b/src/cmd/upgrade.rs
@@ -146,6 +146,7 @@ fn upgrade_plugin(plugin_repo: &PluginRepo) -> anyhow::Result<()> {
                     return Ok(());
                 }
 
+                let original_commit = lock_file_plugin.commit_sha.clone();
                 let old_file_paths: Vec<_> = lock_file_plugin
                     .files
                     .iter()
@@ -166,23 +167,68 @@ fn upgrade_plugin(plugin_repo: &PluginRepo) -> anyhow::Result<()> {
                 };
                 info!("{:?}", updated_plugin);
 
-                utils::copy_plugin_files_from_repo(&repo_path, &mut updated_plugin)?;
+                if let Err(err) =
+                    utils::copy_plugin_files_from_repo(&repo_path, &mut updated_plugin)
+                {
+                    for file in &updated_plugin.files {
+                        let path = file.get_path(&config_dir);
+                        if let Err(cleanup_err) = utils::remove_file_if_exists(&path) {
+                            warn!(
+                                "Failed to clean copied file {} after failed upgrade: {:?}",
+                                path.display(),
+                                cleanup_err
+                            );
+                        }
+                    }
+                    if let Err(restore_err) = git::checkout_commit(&repo, &original_commit) {
+                        warn!(
+                            "Failed to restore repo checkout for {} to {} after failed upgrade: {:?}",
+                            plugin_repo, original_commit, restore_err
+                        );
+                    }
+                    return Err(err);
+                }
 
-                updated_plugin
+                let copied_file_paths: Vec<_> = updated_plugin
+                    .files
+                    .iter()
+                    .map(|file| file.get_path(&config_dir))
+                    .collect();
+                let update_event_names: Vec<_> = updated_plugin
                     .files
                     .iter()
                     .filter(|f| f.dir == TargetDir::ConfD)
-                    .for_each(|f| {
-                        if let Err(e) = utils::emit_event(&f.name, &utils::Event::Update) {
-                            error!("Failed to emit event for {}: {:?}", &f.name, e);
-                        }
-                    });
+                    .map(|f| f.name.clone())
+                    .collect();
 
-                if let Err(e) = lock_file.upsert_plugin_by_repo(updated_plugin) {
-                    warn!("Failed to update lock file: {:?}", e);
+                if let Err(err) = lock_file
+                    .upsert_plugin_by_repo(updated_plugin)
+                    .and_then(|()| lock_file.save(&lock_file_path))
+                {
+                    for path in &copied_file_paths {
+                        if let Err(cleanup_err) = utils::remove_file_if_exists(path) {
+                            warn!(
+                                "Failed to clean copied file {} after failed upgrade: {:?}",
+                                path.display(),
+                                cleanup_err
+                            );
+                        }
+                    }
+                    if let Err(restore_err) = git::checkout_commit(&repo, &original_commit) {
+                        warn!(
+                            "Failed to restore repo checkout for {} to {} after failed upgrade: {:?}",
+                            plugin_repo, original_commit, restore_err
+                        );
+                    }
+                    return Err(err);
                 }
-                lock_file.save(&lock_file_path)?;
                 staged_removals.commit();
+
+                for name in update_event_names {
+                    if let Err(e) = utils::emit_event(&name, &utils::Event::Update) {
+                        error!("Failed to emit event for {}: {:?}", name, e);
+                    }
+                }
             } else {
                 let path_display = repo_path.display();
                 warn!(
@@ -738,6 +784,77 @@ mod tests {
             crate::git::get_latest_commit_sha(&repo).unwrap(),
             fixture.first_commit,
             "repo checkout should not advance when old file removal is rejected"
+        );
+    }
+
+    #[test]
+    fn upgrade_plugin_rolls_back_when_lock_upsert_fails() {
+        let _lock = crate::tests_support::log::env_lock().lock().unwrap();
+        crate::utils::clear_cli_jobs_override_for_tests();
+        let mut fixture = UpgradeFixture::new(false);
+        let _override = EnvOverride::new(&[
+            "PEZ_SUPPRESS_EMIT",
+            "__fish_config_dir",
+            "PEZ_CONFIG_DIR",
+            "PEZ_DATA_DIR",
+        ]);
+        unsafe {
+            std::env::set_var("PEZ_SUPPRESS_EMIT", "1");
+            std::env::set_var("__fish_config_dir", &fixture.env.fish_config_dir);
+            std::env::set_var("PEZ_CONFIG_DIR", &fixture.env.config_dir);
+            std::env::set_var("PEZ_DATA_DIR", &fixture.env.data_dir);
+        }
+
+        let conflict_repo = PluginRepo {
+            host: None,
+            owner: "owner".into(),
+            repo: "conflict".into(),
+        };
+        let mut lock = lock_file::load(&fixture.env.lock_file_path).unwrap();
+        lock.plugins.push(crate::lock_file::Plugin {
+            name: "upgrade".into(),
+            repo: conflict_repo.clone(),
+            source: "https://example.com/owner/conflict".into(),
+            commit_sha: fixture.first_commit.clone(),
+            files: vec![],
+        });
+        fixture.env.setup_lock_file(lock);
+        fixture.env.setup_fish_config();
+
+        let repo_path = fixture.env.data_dir.join(fixture.repo.as_str());
+        let repo = git2::Repository::open(&repo_path).unwrap();
+        crate::git::checkout_commit(&repo, &fixture.first_commit).unwrap();
+
+        let err = upgrade_plugin(&fixture.repo).expect_err("lock upsert failure should abort");
+        let err_text = format!("{:#}", err);
+        assert!(err_text.contains("Plugin already exists"), "{err_text}");
+
+        let saved_lock = lock_file::load(&fixture.env.lock_file_path).unwrap();
+        let saved_plugin = saved_lock.get_plugin_by_repo(&fixture.repo).unwrap();
+        assert_eq!(saved_plugin.commit_sha, fixture.first_commit);
+        assert!(
+            saved_lock
+                .plugins
+                .iter()
+                .any(|plugin| plugin.repo == conflict_repo && plugin.name == "upgrade")
+        );
+
+        let alpha_path = fixture
+            .env
+            .fish_config_dir
+            .join(TargetDir::ConfD.as_str())
+            .join("alpha.fish");
+        let beta_path = fixture
+            .env
+            .fish_config_dir
+            .join(TargetDir::Functions.as_str())
+            .join("beta.fish");
+        assert_eq!(std::fs::read_to_string(alpha_path).unwrap(), "");
+        assert!(beta_path.is_file());
+        assert_eq!(
+            crate::git::get_latest_commit_sha(&repo).unwrap(),
+            fixture.first_commit,
+            "repo checkout should be restored when lock upsert fails"
         );
     }
 

--- a/src/cmd/upgrade.rs
+++ b/src/cmd/upgrade.rs
@@ -151,14 +151,12 @@ fn upgrade_plugin(plugin_repo: &PluginRepo) -> anyhow::Result<()> {
                     .iter()
                     .map(|file| file.get_path(&config_dir))
                     .collect();
-                utils::ensure_files_removable(&old_file_paths)?;
-                git::checkout_commit(&repo, &latest_remote_commit)?;
+                let staged_removals = utils::stage_files_for_removal(&old_file_paths)?;
 
-                for dest_path in &old_file_paths {
-                    if utils::remove_file_if_exists(dest_path)? {
-                        info!("   - {}", dest_path.display());
-                    }
+                for dest_path in staged_removals.removed_paths() {
+                    info!("   - {}", dest_path.display());
                 }
+                git::checkout_commit(&repo, &latest_remote_commit)?;
                 let mut updated_plugin = Plugin {
                     name: lock_file_plugin.name.to_string(),
                     repo: plugin_repo.clone(),
@@ -184,6 +182,7 @@ fn upgrade_plugin(plugin_repo: &PluginRepo) -> anyhow::Result<()> {
                     warn!("Failed to update lock file: {:?}", e);
                 }
                 lock_file.save(&lock_file_path)?;
+                staged_removals.commit();
             } else {
                 let path_display = repo_path.display();
                 warn!(
@@ -705,8 +704,11 @@ mod tests {
             .fish_config_dir
             .join(TargetDir::Functions.as_str())
             .join("beta.fish");
-        std::fs::remove_file(&beta_path).unwrap();
-        std::fs::create_dir_all(&beta_path).unwrap();
+        let functions_dir = beta_path.parent().unwrap();
+        let original_perms = std::fs::metadata(functions_dir).unwrap().permissions();
+        let mut read_only_perms = original_perms.clone();
+        read_only_perms.set_mode(0o500);
+        std::fs::set_permissions(functions_dir, read_only_perms).unwrap();
 
         let repo_path = fixture.env.data_dir.join(fixture.repo.as_str());
         let repo = git2::Repository::open(&repo_path).unwrap();
@@ -714,6 +716,7 @@ mod tests {
 
         let err =
             upgrade_plugin(&fixture.repo).expect_err("file removal failure should abort upgrade");
+        std::fs::set_permissions(functions_dir, original_perms).unwrap();
         let err_text = format!("{:#}", err);
         assert!(err_text.contains("Failed to remove"), "{err_text}");
 
@@ -730,7 +733,7 @@ mod tests {
             alpha_path.exists(),
             "earlier removable files should remain when another file is rejected"
         );
-        assert!(beta_path.is_dir());
+        assert!(beta_path.is_file());
         assert_eq!(
             crate::git::get_latest_commit_sha(&repo).unwrap(),
             fixture.first_commit,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,7 +9,7 @@ use std::{
     collections::HashSet,
     env,
     ffi::OsString,
-    fmt, fs, path, process,
+    fmt, fs, io, path, process,
     sync::{Mutex, OnceLock},
 };
 use tracing::{debug, error, info, warn};
@@ -184,6 +184,14 @@ pub(crate) fn remove_file_if_exists(path: &path::Path) -> anyhow::Result<bool> {
     }
 }
 
+pub(crate) fn remove_dir_all_best_effort(path: &path::Path) {
+    match fs::remove_dir_all(path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+        Err(err) => warn!("Failed to remove directory {}: {:?}", path.display(), err),
+    }
+}
+
 pub(crate) fn ensure_file_removable_if_exists(path: &path::Path) -> anyhow::Result<bool> {
     match fs::symlink_metadata(path) {
         Ok(metadata) => {
@@ -327,7 +335,14 @@ fn unique_staged_removal_path(path: &path::Path, index: usize) -> anyhow::Result
 }
 
 fn path_exists(path: &path::Path) -> bool {
-    fs::symlink_metadata(path).is_ok()
+    match fs::symlink_metadata(path) {
+        Ok(_) => true,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => false,
+        Err(err) => {
+            warn!("Failed to inspect {}: {:?}", path.display(), err);
+            true
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone)]
@@ -607,7 +622,7 @@ mod tests {
     use crate::models::TargetDir;
     use crate::tests_support::env::TestEnvironmentSetup;
     use crate::tests_support::log::{capture_logs, env_lock};
-    use std::ffi::OsString;
+    use std::{ffi::OsString, os::unix::fs::PermissionsExt};
 
     struct EnvGuard {
         vars: Vec<(&'static str, Option<OsString>)>,
@@ -745,6 +760,26 @@ mod tests {
             std::env::remove_var("PEZ_JOBS");
         }
         assert_eq!(load_jobs(), 4);
+    }
+
+    #[test]
+    fn path_exists_treats_metadata_errors_as_existing() {
+        let temp = tempfile::tempdir().unwrap();
+        let restricted_dir = temp.path().join("restricted");
+        std::fs::create_dir_all(&restricted_dir).unwrap();
+        let path = restricted_dir.join("maybe-existing");
+        let original_perms = std::fs::metadata(&restricted_dir).unwrap().permissions();
+        let mut restricted_perms = original_perms.clone();
+        restricted_perms.set_mode(0o000);
+        std::fs::set_permissions(&restricted_dir, restricted_perms).unwrap();
+
+        let exists = path_exists(&path);
+
+        std::fs::set_permissions(&restricted_dir, original_perms).unwrap();
+        assert!(
+            exists,
+            "metadata errors should be treated as existing to avoid overwriting or skipping restore"
+        );
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -207,14 +207,6 @@ pub(crate) fn ensure_file_removable_if_exists(path: &path::Path) -> anyhow::Resu
     }
 }
 
-pub(crate) fn ensure_files_removable(paths: &[path::PathBuf]) -> anyhow::Result<()> {
-    for path in paths {
-        ensure_file_removable_if_exists(path)?;
-    }
-
-    Ok(())
-}
-
 pub(crate) struct StagedFileRemovals {
     entries: Vec<StagedFileRemoval>,
     committed: bool,
@@ -282,8 +274,6 @@ impl Drop for StagedFileRemovals {
 pub(crate) fn stage_files_for_removal(
     paths: &[path::PathBuf],
 ) -> anyhow::Result<StagedFileRemovals> {
-    ensure_files_removable(paths)?;
-
     let mut staged_removals = StagedFileRemovals {
         entries: Vec::new(),
         committed: false,
@@ -294,8 +284,13 @@ pub(crate) fn stage_files_for_removal(
         }
 
         let staged = unique_staged_removal_path(path, index)?;
-        fs::rename(path, &staged)
-            .with_context(|| format!("Failed to remove {}", path.display()))?;
+        match fs::rename(path, &staged) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+            Err(err) => {
+                return Err(err).with_context(|| format!("Failed to remove {}", path.display()));
+            }
+        }
         staged_removals.entries.push(StagedFileRemoval {
             original: path.clone(),
             staged,
@@ -780,6 +775,21 @@ mod tests {
             exists,
             "metadata errors should be treated as existing to avoid overwriting or skipping restore"
         );
+    }
+
+    #[test]
+    fn stage_files_for_removal_skips_missing_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("plugin.fish");
+        std::fs::write(&path, "plugin").unwrap();
+
+        let staged =
+            stage_files_for_removal(&[path.clone(), path.clone()]).expect("stage should succeed");
+
+        assert_eq!(staged.removed_paths().count(), 1);
+        assert!(!path.exists());
+        drop(staged);
+        assert!(path.is_file());
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -174,6 +174,14 @@ pub(crate) fn copy_plugin_files_from_repo(
     Ok(())
 }
 
+pub(crate) fn remove_file_if_exists(path: &path::Path) -> anyhow::Result<bool> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err).with_context(|| format!("Failed to remove {}", path.display())),
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 pub(crate) struct CopyOutcome {
     pub file_count: usize,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -182,6 +182,29 @@ pub(crate) fn remove_file_if_exists(path: &path::Path) -> anyhow::Result<bool> {
     }
 }
 
+pub(crate) fn ensure_file_removable_if_exists(path: &path::Path) -> anyhow::Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            let file_type = metadata.file_type();
+            if file_type.is_file() || file_type.is_symlink() {
+                Ok(true)
+            } else {
+                anyhow::bail!("Failed to remove {}: path is not a file", path.display());
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err).with_context(|| format!("Failed to inspect {}", path.display())),
+    }
+}
+
+pub(crate) fn ensure_files_removable(paths: &[path::PathBuf]) -> anyhow::Result<()> {
+    for path in paths {
+        ensure_file_removable_if_exists(path)?;
+    }
+
+    Ok(())
+}
+
 #[derive(Debug, Default, Clone)]
 pub(crate) struct CopyOutcome {
     pub file_count: usize,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -204,7 +204,27 @@ pub(crate) fn ensure_file_removable_if_exists(path: &path::Path) -> anyhow::Resu
             if file_type.is_file() || file_type.is_symlink() {
                 Ok(true)
             } else {
-                anyhow::bail!("Failed to remove {}: path is not a file", path.display());
+                anyhow::bail!(
+                    "Failed to remove {}: path is not a file or symlink",
+                    path.display()
+                );
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err).with_context(|| format!("Failed to inspect {}", path.display())),
+    }
+}
+
+fn ensure_dir_removable_if_exists(path: &path::Path) -> anyhow::Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_dir() {
+                Ok(true)
+            } else {
+                anyhow::bail!(
+                    "Failed to remove directory {}: path is not a directory",
+                    path.display()
+                );
             }
         }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
@@ -213,11 +233,16 @@ pub(crate) fn ensure_file_removable_if_exists(path: &path::Path) -> anyhow::Resu
 }
 
 pub(crate) struct StagedFileRemovals {
-    entries: Vec<StagedFileRemoval>,
+    entries: Vec<StagedRemovalEntry>,
     committed: bool,
 }
 
-struct StagedFileRemoval {
+pub(crate) struct StagedDirRemovals {
+    entries: Vec<StagedRemovalEntry>,
+    committed: bool,
+}
+
+struct StagedRemovalEntry {
     original: path::PathBuf,
     staged: path::PathBuf,
 }
@@ -233,6 +258,21 @@ impl StagedFileRemovals {
             if let Err(err) = remove_file_if_exists(&entry.staged) {
                 warn!(
                     "Failed to clean staged removal {}: {:?}",
+                    entry.staged.display(),
+                    err
+                );
+            }
+        }
+    }
+}
+
+impl StagedDirRemovals {
+    pub(crate) fn commit(mut self) {
+        self.committed = true;
+        for entry in &self.entries {
+            if let Err(err) = remove_dir_all_if_exists(&entry.staged) {
+                warn!(
+                    "Failed to clean staged directory removal {}: {:?}",
                     entry.staged.display(),
                     err
                 );
@@ -276,6 +316,41 @@ impl Drop for StagedFileRemovals {
     }
 }
 
+impl Drop for StagedDirRemovals {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+
+        for entry in self.entries.iter().rev() {
+            if !path_exists(&entry.staged) {
+                continue;
+            }
+
+            if path_exists(&entry.original)
+                && let Err(err) = remove_dir_all_if_exists(&entry.original)
+            {
+                warn!(
+                    "Failed to restore directory {} from staged removal {}: {:?}",
+                    entry.original.display(),
+                    entry.staged.display(),
+                    err
+                );
+                continue;
+            }
+
+            if let Err(err) = fs::rename(&entry.staged, &entry.original) {
+                warn!(
+                    "Failed to restore directory {} from staged removal {}: {:?}",
+                    entry.original.display(),
+                    entry.staged.display(),
+                    err
+                );
+            }
+        }
+    }
+}
+
 pub(crate) fn stage_files_for_removal(
     paths: &[path::PathBuf],
 ) -> anyhow::Result<StagedFileRemovals> {
@@ -296,7 +371,35 @@ pub(crate) fn stage_files_for_removal(
                 return Err(err).with_context(|| format!("Failed to remove {}", path.display()));
             }
         }
-        staged_removals.entries.push(StagedFileRemoval {
+        staged_removals.entries.push(StagedRemovalEntry {
+            original: path.clone(),
+            staged,
+        });
+    }
+
+    Ok(staged_removals)
+}
+
+pub(crate) fn stage_dirs_for_removal(paths: &[path::PathBuf]) -> anyhow::Result<StagedDirRemovals> {
+    let mut staged_removals = StagedDirRemovals {
+        entries: Vec::new(),
+        committed: false,
+    };
+    for (index, path) in paths.iter().enumerate() {
+        if !ensure_dir_removable_if_exists(path)? {
+            continue;
+        }
+
+        let staged = unique_staged_removal_path(path, index)?;
+        match fs::rename(path, &staged) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("Failed to remove directory {}", path.display()));
+            }
+        }
+        staged_removals.entries.push(StagedRemovalEntry {
             original: path.clone(),
             staged,
         });
@@ -627,7 +730,7 @@ mod tests {
     use crate::models::TargetDir;
     use crate::tests_support::env::TestEnvironmentSetup;
     use crate::tests_support::log::{capture_logs, env_lock};
-    use std::{ffi::OsString, os::unix::fs::PermissionsExt};
+    use std::ffi::OsString;
 
     struct EnvGuard {
         vars: Vec<(&'static str, Option<OsString>)>,
@@ -767,8 +870,11 @@ mod tests {
         assert_eq!(load_jobs(), 4);
     }
 
+    #[cfg(unix)]
     #[test]
     fn path_exists_treats_metadata_errors_as_existing() {
+        use std::os::unix::fs::PermissionsExt;
+
         let temp = tempfile::tempdir().unwrap();
         let restricted_dir = temp.path().join("restricted");
         std::fs::create_dir_all(&restricted_dir).unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,9 @@ use anyhow::Context;
 use console::Emoji;
 use std::{
     collections::HashSet,
-    env, fmt, fs, path,
+    env,
+    ffi::OsString,
+    fmt, fs, path, process,
     sync::{Mutex, OnceLock},
 };
 use tracing::{debug, error, info, warn};
@@ -203,6 +205,129 @@ pub(crate) fn ensure_files_removable(paths: &[path::PathBuf]) -> anyhow::Result<
     }
 
     Ok(())
+}
+
+pub(crate) struct StagedFileRemovals {
+    entries: Vec<StagedFileRemoval>,
+    committed: bool,
+}
+
+struct StagedFileRemoval {
+    original: path::PathBuf,
+    staged: path::PathBuf,
+}
+
+impl StagedFileRemovals {
+    pub(crate) fn removed_paths(&self) -> impl Iterator<Item = &path::Path> {
+        self.entries.iter().map(|entry| entry.original.as_path())
+    }
+
+    pub(crate) fn commit(mut self) {
+        self.committed = true;
+        for entry in &self.entries {
+            if let Err(err) = remove_file_if_exists(&entry.staged) {
+                warn!(
+                    "Failed to clean staged removal {}: {:?}",
+                    entry.staged.display(),
+                    err
+                );
+            }
+        }
+    }
+}
+
+impl Drop for StagedFileRemovals {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+
+        for entry in self.entries.iter().rev() {
+            if !path_exists(&entry.staged) {
+                continue;
+            }
+
+            if path_exists(&entry.original)
+                && let Err(err) = remove_file_if_exists(&entry.original)
+            {
+                warn!(
+                    "Failed to restore {} from staged removal {}: {:?}",
+                    entry.original.display(),
+                    entry.staged.display(),
+                    err
+                );
+                continue;
+            }
+
+            if let Err(err) = fs::rename(&entry.staged, &entry.original) {
+                warn!(
+                    "Failed to restore {} from staged removal {}: {:?}",
+                    entry.original.display(),
+                    entry.staged.display(),
+                    err
+                );
+            }
+        }
+    }
+}
+
+pub(crate) fn stage_files_for_removal(
+    paths: &[path::PathBuf],
+) -> anyhow::Result<StagedFileRemovals> {
+    ensure_files_removable(paths)?;
+
+    let mut staged_removals = StagedFileRemovals {
+        entries: Vec::new(),
+        committed: false,
+    };
+    for (index, path) in paths.iter().enumerate() {
+        if !ensure_file_removable_if_exists(path)? {
+            continue;
+        }
+
+        let staged = unique_staged_removal_path(path, index)?;
+        fs::rename(path, &staged)
+            .with_context(|| format!("Failed to remove {}", path.display()))?;
+        staged_removals.entries.push(StagedFileRemoval {
+            original: path.clone(),
+            staged,
+        });
+    }
+
+    Ok(staged_removals)
+}
+
+fn unique_staged_removal_path(path: &path::Path, index: usize) -> anyhow::Result<path::PathBuf> {
+    let parent = path
+        .parent()
+        .with_context(|| format!("Failed to remove {}: path has no parent", path.display()))?;
+    let file_name = path
+        .file_name()
+        .with_context(|| format!("Failed to remove {}: path has no file name", path.display()))?;
+
+    for attempt in 0..1000 {
+        let mut staged_name = OsString::from(".pez-removing-");
+        staged_name.push(process::id().to_string());
+        staged_name.push("-");
+        staged_name.push(index.to_string());
+        staged_name.push("-");
+        staged_name.push(attempt.to_string());
+        staged_name.push("-");
+        staged_name.push(file_name);
+        let candidate = parent.join(staged_name);
+        if !path_exists(&candidate) {
+            return Ok(candidate);
+        }
+    }
+
+    anyhow::bail!(
+        "Failed to remove {}: no staging path available",
+        path.display()
+    );
+}
+
+fn path_exists(path: &path::Path) -> bool {
+    fs::symlink_metadata(path).is_ok()
 }
 
 #[derive(Debug, Default, Clone)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,7 +10,10 @@ use std::{
     env,
     ffi::OsString,
     fmt, fs, io, path, process,
-    sync::{Mutex, OnceLock},
+    sync::{
+        Mutex, OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 use tracing::{debug, error, info, warn};
 use walkdir::WalkDir;
@@ -184,11 +187,13 @@ pub(crate) fn remove_file_if_exists(path: &path::Path) -> anyhow::Result<bool> {
     }
 }
 
-pub(crate) fn remove_dir_all_best_effort(path: &path::Path) {
+pub(crate) fn remove_dir_all_if_exists(path: &path::Path) -> anyhow::Result<bool> {
     match fs::remove_dir_all(path) {
-        Ok(()) => {}
-        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
-        Err(err) => warn!("Failed to remove directory {}: {:?}", path.display(), err),
+        Ok(()) => Ok(true),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(err) => {
+            Err(err).with_context(|| format!("Failed to remove directory {}", path.display()))
+        }
     }
 }
 
@@ -301,16 +306,21 @@ pub(crate) fn stage_files_for_removal(
 }
 
 fn unique_staged_removal_path(path: &path::Path, index: usize) -> anyhow::Result<path::PathBuf> {
+    static NEXT_STAGED_REMOVAL_ID: AtomicU64 = AtomicU64::new(0);
+
     let parent = path
         .parent()
         .with_context(|| format!("Failed to remove {}: path has no parent", path.display()))?;
     let file_name = path
         .file_name()
         .with_context(|| format!("Failed to remove {}: path has no file name", path.display()))?;
+    let removal_id = NEXT_STAGED_REMOVAL_ID.fetch_add(1, Ordering::Relaxed);
 
     for attempt in 0..1000 {
         let mut staged_name = OsString::from(".pez-removing-");
         staged_name.push(process::id().to_string());
+        staged_name.push("-");
+        staged_name.push(removal_id.to_string());
         staged_name.push("-");
         staged_name.push(index.to_string());
         staged_name.push("-");
@@ -790,6 +800,17 @@ mod tests {
         assert!(!path.exists());
         drop(staged);
         assert!(path.is_file());
+    }
+
+    #[test]
+    fn unique_staged_removal_path_returns_distinct_candidates_for_same_input() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("plugin.fish");
+
+        let first = unique_staged_removal_path(&path, 0).unwrap();
+        let second = unique_staged_removal_path(&path, 0).unwrap();
+
+        assert_ne!(first, second);
     }
 
     #[test]


### PR DESCRIPTION
This pull request refactors how plugin files are removed throughout the codebase, centralizing file removal logic into a new utility function and improving error handling. It also adds comprehensive tests to ensure that state is preserved if file removal fails, preventing partial or inconsistent updates to configuration and lock files.

**Centralized file removal and improved error handling:**

- Introduced a new utility function `remove_file_if_exists` in `utils.rs` that removes a file if it exists, returns a boolean indicating removal, and provides detailed error context if removal fails.
- Refactored file removal in `install.rs`, `prune.rs`, `uninstall.rs`, and `upgrade.rs` to use `remove_file_if_exists`, ensuring consistent behavior and error reporting across commands. [[1]](diffhunk://#diff-dd816aa02270455964eb003cdbeab3b63a9769f147c581421b38182d9e3c7a25L634-R635) [[2]](diffhunk://#diff-15d4c1d0e6f1e7919fe021c9f8a4ae3601005f7d7f98b310f13b454f57cabd61L159-L168) [[3]](diffhunk://#diff-15d4c1d0e6f1e7919fe021c9f8a4ae3601005f7d7f98b310f13b454f57cabd61L261-R264) [[4]](diffhunk://#diff-d9d60d1f6558bbac9286fbfa98881800972c7919f092038db697500e7f4a5f28L128-L137) [[5]](diffhunk://#diff-559b99cc491026d680606e6d4832064f42b2e7d384d86ec9ad384fb01c697e23L152-L159)

**State preservation and test coverage:**

- Added tests in `install.rs`, `prune.rs`, `uninstall.rs`, and `upgrade.rs` to verify that if file removal fails, the lock file and configuration are not updated, and the plugin remains registered. This prevents partial uninstall/upgrade/prune operations. [[1]](diffhunk://#diff-dd816aa02270455964eb003cdbeab3b63a9769f147c581421b38182d9e3c7a25R1742-R1797) [[2]](diffhunk://#diff-15d4c1d0e6f1e7919fe021c9f8a4ae3601005f7d7f98b310f13b454f57cabd61R849-R880) [[3]](diffhunk://#diff-d9d60d1f6558bbac9286fbfa98881800972c7919f092038db697500e7f4a5f28R546-R611) [[4]](diffhunk://#diff-559b99cc491026d680606e6d4832064f42b2e7d384d86ec9ad384fb01c697e23R673-R729)

**Code cleanup:**

- Removed direct usage of `std::fs` for file removal in favor of the new utility.

These changes significantly improve the reliability and maintainability of plugin file management by ensuring atomic operations and clear error propagation.