### PR TITLE
docs: refresh project documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pez"
 version = "0.4.2"
 edition = "2024"
-description = "A Rust-based plugin manager for fish."
+description = "A lockfile-backed plugin manager for fish."
 homepage = "https://github.com/tetzng/pez"
 readme = "README.md"
 repository = "https://github.com/tetzng/pez"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ result with `pez doctor` before removing another plugin manager.
 
 - Lockfile state for installed commits and copied files
 - GitHub shorthand, host-prefixed repos, full Git URLs, and local plugin paths
-- Duplicate destination checks before plugin files are recorded
+- Run-level duplicate destination checks for copied plugin files
 - `doctor`, `files`, `list --outdated`, `upgrade`, and `prune` commands for routine maintenance
 - A guided migration path from fisher
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ result with `pez doctor` before removing another plugin manager.
 
 - Lockfile state for installed commits and copied files
 - GitHub shorthand, host-prefixed repos, full Git URLs, and local plugin paths
-- Run-level duplicate destination checks for copied plugin files
+- `doctor` checks for missing files, duplicate destinations, and theme assets
 - `doctor`, `files`, `list --outdated`, `upgrade`, and `prune` commands for routine maintenance
 - A guided migration path from fisher
 

--- a/README.md
+++ b/README.md
@@ -1,40 +1,38 @@
-<h1 align="center">pez</h1>
+# pez
 
-<p align="center"><strong>A Rust-based plugin manager for <a href="https://fishshell.com/">fish</a></strong></p>
+A lockfile-backed plugin manager for fish.
 
-<p align="center">
-  <em>Experimental</em> — use at your own risk.
-</p>
+pez installs fish plugins from Git repositories or local paths, copies their
+fish assets into the standard config directories, and records the exact
+installed state in `pez-lock.toml`.
 
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tetzng/pez)
+Status: experimental. Back up your fish config before migrating, and verify the
+result with `pez doctor` before removing another plugin manager.
 
-## Overview
+## Why pez?
 
-pez is a Rust-based plugin manager for fish. It installs plugins by cloning
-repositories, copying fish assets into the standard directories, and tracking
-state in a lockfile.
+- Lockfile state for installed commits and copied files
+- GitHub shorthand, host-prefixed repos, full Git URLs, and local plugin paths
+- Duplicate destination checks before plugin files are recorded
+- `doctor`, `files`, `list --outdated`, `upgrade`, and `prune` commands for routine maintenance
+- A guided migration path from fisher
 
-## Features
+## Install
 
-- GitHub shorthand and non-GitHub hosts (URL or `host/owner/repo`)
-- Lockfile with exact commits and installed file records
-- Duplicate destination detection to avoid overwrites
-- `upgrade`, `prune`, and `doctor` utilities
-- Optional activation wrapper to emit conf.d events in the current shell
+Use a prebuilt binary from [GitHub Releases](https://github.com/tetzng/pez/releases)
+when one is available.
 
-## Installation
-
-Install with Cargo:
+With Cargo:
 
 ```sh
-# From crates.io (if available)
 cargo install pez
-
-# From source (in this repo)
-cargo install --path .
 ```
 
-Or use a prebuilt release binary (when available), which does not require Cargo.
+From this checkout:
+
+```sh
+cargo install --path .
+```
 
 With Nix flakes:
 
@@ -42,71 +40,51 @@ With Nix flakes:
 nix run github:tetzng/pez -- --version
 ```
 
-If flakes are not enabled globally, run it as
-`nix --extra-experimental-features 'nix-command flakes' run github:tetzng/pez -- --version`.
+More options: [docs/install.md](docs/install.md)
 
-## Quickstart
+## Quick Start
+
+Create the config file:
 
 ```fish
-# 1) Initialize configuration (creates pez.toml)
 pez init
+```
 
-# 2) Add a plugin to pez.toml (choose one of repo/url/path)
-#    [[plugins]]
-#    repo = "owner/repo"      # GitHub shorthand
-#    # version = "v3"        # Or: tag = "...", branch = "...", commit = "..."
-#
-#    # [[plugins]]
-#    # url = "https://gitlab.com/owner/repo"  # Any Git host URL
-#    # branch = "main"
-#
-#    # [[plugins]]
-#    # path = "~/path/to/local/plugin"       # Local directory (absolute or ~/ only)
-#    # Note: when specifying a relative path or ~/ at the CLI (e.g., ./plugin), pez normalizes it to an absolute path in pez.toml.
+Add a plugin to `pez.toml`:
 
-# 3) Install plugins listed in pez.toml
+```toml
+[[plugins]]
+repo = "owner/repo"
+```
+
+Install and inspect:
+
+```fish
 pez install
-
-# 4) Verify installation
 pez list --format table
+pez doctor
+```
 
-# 5) (Optional) Enable completions for pez itself
-pez completions fish > ~/.config/fish/completions/pez.fish
+Install a single plugin directly:
 
-# 6) (Optional) Activate fish shell hooks (emit conf.d events in the current shell)
+```fish
+pez install owner/repo
+pez install gitlab.com/owner/repo@branch:main
+pez install ./local-plugin
+```
+
+Enable hooks in the current shell when plugins rely on `conf.d` events:
+
+```fish
 pez activate fish | source
 ```
 
-## Shell Completions
-
-```fish
-pez completions fish > ~/.config/fish/completions/pez.fish
-```
-
-Completions are intentionally Fish-only.
-
-## Shell Activation
-
-```fish
-# Enable conf.d events in the current shell for install/upgrade/uninstall
-pez activate fish | source
-```
-
-For persistence, add it inside an `if status is-interactive ... end` block in `~/.config/fish/config.fish`.
-
-## Docs & FAQ
-
-- [Getting started](docs/getting-started.md)
-  - [Quick start](docs/getting-started.md#quick-start)
-  - [CLI usage](docs/getting-started.md#cli-usage-examples)
-- [Command reference](docs/commands.md)
-- [Configuration](docs/configuration.md)
-- [Architecture](docs/architecture.md)
-- [Install & build](docs/install.md)
-- [Migrate from fisher](docs/migrate-from-fisher.md)
-- [FAQ](docs/faq.md)
+Persist that activation from `~/.config/fish/config.fish` inside an
+interactive-shell guard.
 
 ## Migrate from fisher
+
+Use the low-risk path:
 
 ```fish
 pez activate fish | source
@@ -116,88 +94,27 @@ pez list --format table
 pez doctor
 ```
 
+Only remove fisher after the migrated setup looks correct.
+
 Details: [docs/migrate-from-fisher.md](docs/migrate-from-fisher.md)
 
-## Usage (overview)
+## Docs
 
-```fish
-Usage: pez [OPTIONS] <COMMAND>
-
-Commands:
-  init | install | uninstall | upgrade | list | prune | completions | activate | doctor | migrate | files
-
-Options:
-  -v, --verbose  Increase output verbosity (-v for info, -vv for debug)
-  --jobs <N>     Override parallel job limit (default: 4; overrides PEZ_JOBS)
-  -h, --help     Print help
-  -V, --version  Print version
-```
-
-Common examples
-
-```fish
-pez init
-pez install                 # install from pez.toml
-pez install owner/repo      # install a specific plugin
-pez upgrade                 # update non-local plugins to remote HEAD
-pez list --outdated --format table
-pez prune --dry-run
-```
-
-See the full command reference in [docs/commands.md](docs/commands.md).
-
-## Configuration
-
-pez uses `pez.toml` and `pez-lock.toml` under the fish config directory by
-default. Configuration file precedence is:
-`$PEZ_CONFIG_DIR` > `$__fish_config_dir` > `$XDG_CONFIG_HOME/fish` > `~/.config/fish`.
-
-`PEZ_TARGET_DIR` only affects where plugin files are copied. For schema,
-location details, and environment variables, see [docs/configuration.md](docs/configuration.md).
-
-To regenerate the config schema:
-
-```sh
-cargo run --features schema-gen --bin gen-config-schema
-```
-
-For install/upgrade behavior (selectors, duplicates, concurrency, existing
-clones), see [docs/commands.md](docs/commands.md).
-
-## Troubleshooting
-
-- `pez doctor` checks config/lock/data directories and copied files.
-- `pez list --format json` shows the current lockfile state.
-- `pez files --all` lists installed file paths.
+- [Getting started](docs/getting-started.md)
+- [Command reference](docs/commands.md)
+- [Configuration and lockfile](docs/configuration.md)
+- [Install and build](docs/install.md)
+- [Migrate from fisher](docs/migrate-from-fisher.md)
+- [FAQ](docs/faq.md)
+- [Architecture](docs/architecture.md)
 
 ## Security
 
-pez installs plugin files from third-party repositories. If you enable the
-activation wrapper, `conf.d` scripts are sourced in the current shell. pez does
-not verify signatures or sandbox code. Only install plugins you trust.
-
-## Contributing
-
-There is no formal contributing guide yet. If you want to help, open a PR and
-run `cargo fmt --all`, `cargo clippy --workspace --all-targets --all-features`,
-and `cargo test --all-features`.
-
-## Changelog
-
-No dedicated changelog is maintained yet. Use git history to review changes.
-
-## Acknowledgements
-
-pez is inspired by the following projects:
-
-- [fisher](https://github.com/jorgebucaran/fisher)
-- [oh-my-fish](https://github.com/oh-my-fish/oh-my-fish)
-- [fundle](https://github.com/danhper/fundle)
+pez installs code from third-party repositories into your fish configuration.
+It does not verify signatures or sandbox plugin code. Install plugins you trust,
+review migration changes before removing fisher, and keep `pez doctor` in your
+verification flow.
 
 ## License
 
 [MIT](./LICENSE)
-
-## Author
-
-tetzng

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,8 +24,8 @@ and dispatches each command through `src/cmd/`.
 3. Clone remote repos into the pez data directory. Local path sources skip clone.
 4. Resolve the selected revision.
 5. Copy supported fish assets into the target fish config directory.
-6. Detect duplicate destinations before recording files.
-7. Write installed state to `pez-lock.toml`.
+6. Apply run-level duplicate destination checks while copying files.
+7. Write installed state and copied file records to `pez-lock.toml`.
 8. Emit hook events for eligible `conf.d` files.
 
 Explicit CLI installs clone concurrently and then copy files sequentially.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,14 +1,15 @@
 # Architecture
 
-pez is a single Rust CLI. `src/main.rs` sets up logging, parses CLI arguments,
-and dispatches each command through `src/cmd/`.
+pez is a single Rust CLI. `src/main.rs` is the Tokio entrypoint and calls
+`pez::run()`. `src/lib.rs` parses CLI arguments, configures color and logging,
+and dispatches commands through `src/cmd/`.
 
 ## Module Map
 
 | Module | Responsibility |
 | --- | --- |
 | `src/cli.rs` | `clap` definitions for commands, arguments, and CLI target parsing. |
-| `src/cmd/` | Command orchestration. Each command exposes `pub(crate) run`. |
+| `src/cmd/` | Command orchestration. Most commands expose `pub(crate) run`; shell-output helpers such as activation and completion use dedicated functions. |
 | `src/config.rs` | Load, validate, and save `pez.toml`; convert config entries to install targets. |
 | `src/lock_file.rs` | Load, validate, and save `pez-lock.toml`; resolve installed files. |
 | `src/models.rs` | Shared types such as `PluginRepo`, `InstallTarget`, and `TargetDir`. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,12 +24,15 @@ and dispatches each command through `src/cmd/`.
 3. Clone remote repos into the pez data directory. Local path sources skip clone.
 4. Resolve the selected revision.
 5. Copy supported fish assets into the target fish config directory.
-6. Apply run-level duplicate destination checks while copying files.
-7. Write installed state and copied file records to `pez-lock.toml`.
-8. Emit hook events for eligible `conf.d` files.
+6. Apply run-level duplicate destination checks on dedupe-enabled install paths.
+7. For raw commands, emit out-of-process hook events for eligible `conf.d`
+   files unless `PEZ_SUPPRESS_EMIT=1` is set.
+8. Write installed state and copied file records to `pez-lock.toml`.
 
 Explicit CLI installs clone concurrently and then copy files sequentially.
-Config-driven installs are sequential.
+Config-driven installs are sequential. Fresh config-driven entries use direct
+copying; explicit CLI installs and config-driven entries that copy an already
+tracked plugin use dedupe-enabled copying.
 
 ## Upgrade Flow
 
@@ -63,12 +66,16 @@ Environment overrides are documented in [configuration](configuration.md).
 
 pez has two hook paths:
 
-- Raw commands emit eligible events out of process.
+- Raw commands emit eligible events out of process. Raw `install` emits before
+  the lockfile write; raw `upgrade` and `uninstall` emit after state updates
+  succeed.
 - `pez activate fish | source` installs a fish wrapper so hooks run in the
   current shell.
 
 The activation wrapper suppresses duplicate raw emits by setting
-`PEZ_SUPPRESS_EMIT=1`.
+`PEZ_SUPPRESS_EMIT=1`. It emits install and upgrade hooks in the current shell
+after the raw command succeeds, and emits uninstall hooks before the raw
+uninstall command while recorded files still exist.
 
 ## Documentation Boundaries
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,52 +1,78 @@
 # Architecture
 
-This document outlines the high‑level structure and flows in pez.
+pez is a single Rust CLI. `src/main.rs` sets up logging, parses CLI arguments,
+and dispatches each command through `src/cmd/`.
 
-## Overview
+## Module Map
 
-- `main.rs` initializes logging and dispatches to subcommands defined in `cli.rs` and implemented under `cmd/*`.
-- Core modules:
-  - `models.rs`: shared domain types (PluginRepo, InstallTarget, ResolvedInstallTarget, TargetDir).
-  - `config.rs`: load/save `pez.toml`, convert entries to install targets.
-  - `lock_file.rs`: load/save `pez-lock.toml`, track installed plugins and copied files.
-  - `resolver.rs`: parse refs (latest/version/tag/branch/commit) and map to `Selection`.
-  - `git.rs`: resolve selections against a repo (branches/tags/commits), list tags.
-  - `utils.rs`: path/env resolution, copy routines, events, helpers.
-  - `cmd/*`: end‑user commands orchestrating core modules.
-    - `cmd/activate.rs`: emits Fish wrapper code to run hooks in the current shell.
-    - `cmd/files.rs`: lists installed file paths from the lockfile (used by activation).
+| Module | Responsibility |
+| --- | --- |
+| `src/cli.rs` | `clap` definitions for commands, arguments, and CLI target parsing. |
+| `src/cmd/` | Command orchestration. Each command exposes `pub(crate) run`. |
+| `src/config.rs` | Load, validate, and save `pez.toml`; convert config entries to install targets. |
+| `src/lock_file.rs` | Load, validate, and save `pez-lock.toml`; resolve installed files. |
+| `src/models.rs` | Shared types such as `PluginRepo`, `InstallTarget`, and `TargetDir`. |
+| `src/resolver.rs` | Convert refs into selection semantics such as latest, version, branch, tag, and commit. |
+| `src/git.rs` | Clone repositories, fetch refs, resolve selections, and checkout commits. |
+| `src/utils.rs` | Path resolution, file copying, hook emitting, staged cleanup, and shared helpers. |
+| `src/tests_support/` | Isolated test environment and log helpers. |
 
-## Data Flow (install)
+## Install Flow
 
-1. Normalize CLI targets (or entries in `pez.toml`) into `InstallTarget` values.
-2. Convert each `InstallTarget` to a `ResolvedInstallTarget` (source, ref_kind, is_local).
-3. Clone remote sources; skip clone for local paths.
-4. Resolve the commit using `resolver::RefKind` -> `git::resolve_selection`.
-5. Copy files to the Fish config directory using `utils::copy_plugin_files*`.
-6. Update the lockfile with `name`/`repo`/`source`/`commit_sha`/`files`.
-7. For files under `conf.d` with safe stems, emit `<stem>_{install|update|uninstall}` fish events at the command-specific hook point; raw uninstall emits run after cleanup and state updates succeed.
+1. Load or create `pez.toml` and `pez-lock.toml`.
+2. Resolve CLI targets or config entries into `ResolvedInstallTarget` values.
+3. Clone remote repos into the pez data directory. Local path sources skip clone.
+4. Resolve the selected revision.
+5. Copy supported fish assets into the target fish config directory.
+6. Detect duplicate destinations before recording files.
+7. Write installed state to `pez-lock.toml`.
+8. Emit hook events for eligible `conf.d` files.
 
-## Concurrency
+Explicit CLI installs clone concurrently and then copy files sequentially.
+Config-driven installs are sequential.
 
-- `--jobs <N>` globally overrides concurrency for `upgrade`, `uninstall`, `prune`,
-  and the clone phase of `install` when explicit targets are provided. When the
-  flag is absent, `PEZ_JOBS` acts as the environment override (default: 4).
-- `install` concurrency depends on how it is invoked:
-  - With explicit targets (`install <targets...>`): clones run concurrently
-    (bounded by the configured job limit), file copies run sequentially with
-    duplicate‑path detection and warnings.
-  - From `pez.toml` (no targets): processing is sequential and uses the same
-    duplicate‑path detection; conflicting plugins are skipped with a warning.
+## Upgrade Flow
 
-## Paths and Resolution
+1. Read the current lockfile.
+2. Find matching config entries when selectors are present.
+3. Skip local path sources.
+4. Resolve the target remote revision.
+5. Remove old copied files through staged cleanup.
+6. Checkout the new commit, copy files, and update the lockfile.
+7. Restore staged files when a later state write fails.
 
-- Config dir precedence: `PEZ_CONFIG_DIR` > `__fish_config_dir` > `XDG_CONFIG_HOME/fish` > `~/.config/fish`.
-- `PEZ_TARGET_DIR` only adjusts the copy destination; configuration and lock files stay under the config precedence above.
-- Data dir precedence: `PEZ_DATA_DIR` > `__fish_user_data_dir/pez` > `XDG_DATA_HOME/fish/pez` > `~/.local/share/fish/pez`.
-- Copy destination: defaults to the Fish config directory and can be overridden via `PEZ_TARGET_DIR` (or falls back to `__fish_config_dir` / `XDG_CONFIG_HOME/fish`).
+## Uninstall and Prune Flow
 
-## Upgrade Semantics
+`uninstall` removes named plugins. `prune` removes plugins present in the
+lockfile but absent from `pez.toml`.
 
-- Local sources are skipped.
-- If a selector is specified in `pez.toml` (`version`/`branch`/`tag`/`commit`), `upgrade` resolves against that selector.
-- When no selector is set, non‑local plugins update to the latest commit on the remote default branch (remote HEAD).
+Both flows use staged file and directory removals so failures can preserve or
+restore state before the command reports an error.
+
+## Path Model
+
+| State | Default |
+| --- | --- |
+| Config and lockfile | `~/.config/fish` |
+| Cached repos | `~/.local/share/fish/pez` |
+| Copied plugin files | fish config directory |
+
+Environment overrides are documented in [configuration](configuration.md).
+
+## Hook Model
+
+pez has two hook paths:
+
+- Raw commands emit eligible events out of process.
+- `pez activate fish | source` installs a fish wrapper so hooks run in the
+  current shell.
+
+The activation wrapper suppresses duplicate raw emits by setting
+`PEZ_SUPPRESS_EMIT=1`.
+
+## Documentation Boundaries
+
+- User workflow: [README](../README.md), [getting started](getting-started.md)
+- Exact command behavior: [commands](commands.md)
+- Config, lockfile, paths, and environment: [configuration](configuration.md)
+- Migration risk and fisher mapping: [migrate from fisher](migrate-from-fisher.md)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -216,8 +216,10 @@ in the current shell.
 
 When active:
 
-- `install` and `upgrade` source affected `conf.d` files and emit
-  `<stem>_install` or `<stem>_update`.
+- `install` and `upgrade` source `conf.d` files selected by
+  `pez files --from ...` and emit `<stem>_install` or `<stem>_update`.
+  With explicit plugin targets, the selection follows those targets. With no
+  targets, it uses the current lockfile entries.
 - `uninstall` emits `<stem>_uninstall` before running the raw uninstall command.
 - The wrapper sets `PEZ_SUPPRESS_EMIT=1` to avoid duplicate out-of-process
   emits.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,8 +8,8 @@ Global options:
 
 | Option | Meaning |
 | --- | --- |
-| `-v`, `--verbose` | Log verbosity flag. Logs default to info; use `-vv` for debug logs. |
-| `--jobs <N>` | Override parallel work for explicit install clones, `upgrade`, `uninstall`, and `prune`. Must be at least 1. |
+| `-v`, `--verbose` | Increase log verbosity. Logs default to info; use `-vv` for debug logs. |
+| `--jobs <N>` | Set the number of parallel jobs for explicit install clones, `upgrade`, `uninstall`, and `prune`. Must be at least 1. |
 | `-h`, `--help` | Print help. |
 | `-V`, `--version` | Print version. |
 
@@ -224,8 +224,8 @@ When active:
 - The wrapper sets `PEZ_SUPPRESS_EMIT=1` to avoid duplicate out-of-process
   emits.
 
-Out-of-process emits only run for safe stems made from `A-Z`, `a-z`, `0-9`,
-`_`, `-`, and `.`.
+Out-of-process hook events are emitted only for safe stems containing only
+`A-Z`, `a-z`, `0-9`, `_`, `-`, and `.`.
 
 ## migrate
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,139 +1,240 @@
 # Command Reference
 
-## Contents
-
-- [Usage](#usage)
-- [Commands](#commands)
-  - [init](#init)
-  - [install](#install)
-  - [uninstall](#uninstall)
-  - [upgrade](#upgrade)
-  - [list](#list)
-  - [prune](#prune)
-  - [doctor](#doctor)
-  - [completions](#completions)
-  - [activate](#activate)
-  - [files](#files)
-  - [migrate](#migrate)
-
-## Usage
-
 ```text
 pez [OPTIONS] <COMMAND>
 ```
 
-Global options (apply to all commands)
+Global options:
 
-| Option | Description |
+| Option | Meaning |
 | --- | --- |
-| `-v, --verbose` | Increase verbosity. Default is info; `-vv` enables debug. |
-| `--jobs <N>` | Override parallel job limit for commands that spawn concurrent tasks (defaults to 4; overrides `PEZ_JOBS`). |
-| `-V, --version` | Print version. |
-| `-h, --help` | Print help. |
+| `-v`, `--verbose` | Increase log verbosity. Use `-vv` for debug logs. |
+| `--jobs <N>` | Override parallel work for explicit install clones, `upgrade`, `uninstall`, and `prune`. Must be at least 1. |
+| `-h`, `--help` | Print help. |
+| `-V`, `--version` | Print version. |
 
-## Commands
+`PEZ_JOBS` provides the default job count when `--jobs` is not set. The fallback
+is 4.
 
-### init
+## init
 
-- Initialize `pez.toml` under the configuration directory. Fails if it already exists.
+```sh
+pez init
+```
 
-### install
+Creates `pez.toml` in the config directory. The command fails if the file
+already exists.
 
-- Install from CLI targets or from `pez.toml` (when no targets are given).
-- Targets: `owner/repo[@ref]`, `host/owner/repo[@ref]`, full URL, local paths (absolute, `~/`, or relative).
-- Options:
-  - `--force` Reinstall even if the target already exists.
-  - `--prune` (only available when running without explicit targets) removes lockfile entries that are no longer declared in `pez.toml` after a successful install.
-- Behavior:
-  - CLI‑specified targets are appended to `pez.toml`; relative paths and `~/` are normalized to absolute paths before writing.
-  - `owner/repo` resolves to `https://github.com/owner/repo`; `host/...` without a scheme is normalized to `https://host/...`.
-  - Selectors: `@latest`, `@version:<v>`, `@branch:<b>`, `@tag:<t>`, `@commit:<sha>` influence the resolved commit for fresh installs and `install --force`.
-  - `@ref` parsing applies to shorthand/host targets without a scheme; full URLs are treated as literal strings. Use `pez.toml` to pin refs for URL installs.
-  - File selection: only `.fish` files are copied from `functions`/`completions`/`conf.d`, and only `.theme` files from `themes`.
-  - Duplicate files: pez tracks destination paths seen during the run and skips a plugin if copying would overwrite an existing file (applies to both CLI targets and `pez.toml`). A warning is printed and the plugin’s files are not recorded.
-  - Concurrency: with explicit targets, clones run concurrently (bounded by `--jobs` or `PEZ_JOBS`) and file copies run sequentially with duplicate‑path detection; installs from `pez.toml` are processed sequentially with the same duplicate detection.
-  - Existing clones: CLI targets are skipped with a warning unless you pass `--force`, which removes the cached clone before re-cloning. When running from `pez.toml`, entries that already exist in `pez-lock.toml` and on disk are treated as up to date and skipped unless you pass `--force`; when `--force` is present, pez deletes the cached clone before re-cloning so config-driven installs behave the same as explicit targets. If a clone exists without a matching lockfile entry, pez returns an error unless you pass `--force`.
-  - Clone path layout: remote repos live under `<host>/<owner>/<repo>` in the data directory. GitHub shorthand (`owner/repo`) continues to resolve to `github.com`.
-  - With `--prune`, pez removes lockfile entries that are no longer declared in `pez.toml` after a successful install (similar to `pez prune`).
+## install
 
-### uninstall
+```sh
+pez install [OPTIONS] [PLUGINS]...
+```
 
-- Remove the specified plugins (`owner/repo` or `host/owner/repo`). With `--stdin`, also read plugin repos from standard input (one per line).
-- Options:
-  - `--force` Remove files recorded in the lockfile even if the repository directory is missing.
-  - `--stdin` Read `owner/repo` or `host/owner/repo` values from stdin. Blank lines and lines starting with `#` are ignored; the remaining entries are sorted and deduplicated before processing.
-- Behavior: removes the cloned repository (if present) and the files recorded in `pez-lock.toml`, then removes the matching entry from `pez.toml` to keep the configuration in sync. Without `--force` when the repo directory is missing, the command prints the target files and exits.
-- Example:
-  - `printf "owner/a\nowner/b\n" | pez uninstall --stdin`
+Installs plugins from CLI targets or, when no targets are provided, from
+`pez.toml`.
 
-### upgrade
+Accepted CLI targets:
 
-- Upgrade specified plugins (`owner/repo` or `host/owner/repo`), or with no arguments, upgrade plugins listed in `pez.toml`.
-- Respects selectors in `pez.toml` (`version`/`branch`/`tag`/`commit`). When no selector is set, updates to the latest commit on the remote default branch (remote HEAD).
-- Local path sources (`path`) are skipped.
-- Concurrency is controlled by `--jobs` or `PEZ_JOBS`.
-- Any repo specified on the CLI that is not already in `pez.toml` is added automatically so future installs remain in sync.
+- `owner/repo[@ref]`
+- `host/owner/repo[@ref]`
+- Full Git URLs such as `https://example.com/owner/repo.git`
+- Local paths beginning with `/`, `~/`, `./`, or `../`
 
-### list
+Options:
 
-- Show installed plugins recorded in `pez-lock.toml`.
-- Options:
-  - `--format [plain|table|json]`
-  - `--outdated`
-  - `--filter [all|local|remote]`
-- Filtering is based on the plugin source: `local` shows only path-based installs, `remote` keeps Git-backed sources.
-- Fields:
-  - table: `name`, `repo`, `source`, `selector`, `commit`
-  - json: `name`, `repo`, `source`, `selector`, `commit`
-  - `list --outdated` (json/table): `name`, `repo`, `source`, `current`, `latest`
+| Option | Meaning |
+| --- | --- |
+| `-f`, `--force` | Reinstall even when the plugin already exists. |
+| `-p`, `--prune` | After a config-driven install, remove lockfile entries no longer listed in `pez.toml`. Cannot be used with explicit plugin targets. |
 
-### prune
+Selector syntax for shorthand and host-prefixed targets:
 
-- Remove plugins that exist only in the lockfile (i.e., not listed in `pez.toml`).
-- Options: `--dry-run`, `--yes`, `--force` (remove destination files even if the repo dir is missing).
-- Behavior: if `pez.toml` has no `[[plugins]]` entries (plugins list missing), the command warns and asks for confirmation unless `--yes` is provided.
+| Selector | Meaning |
+| --- | --- |
+| `owner/repo@v3` | Version selector. Branches are preferred over tags with the same name. |
+| `owner/repo@branch:main` | Branch selector. |
+| `owner/repo@tag:v1.2.3` | Tag selector. |
+| `owner/repo@commit:<sha>` | Commit selector. |
+| `owner/repo@latest` | Remote default branch. |
 
-### doctor
+Full URLs are treated literally and are not split on `@ref`. Use `pez.toml` to
+pin URL sources.
 
-- Checks the configuration file, lockfile, data/config directories, and the set of copied files.
-- Reported checks include: `config`, `lock_file`, `fish_config_dir`, `pez_data_dir`, `activate_configured`, `event_hook_readiness`, `install_layout`, `repos` (missing clones), `target_files` (missing files), `duplicates` (conflicting destinations), `theme_assets`.
-- Options: `--format json`.
+Install behavior:
 
-### completions
+- CLI targets are appended to `pez.toml` if they are not already present.
+- CLI relative paths and `~/` paths are normalized before they are saved.
+- Explicit remote targets clone concurrently, bounded by `--jobs` or `PEZ_JOBS`.
+- Config-driven installs run sequentially.
+- File copying is sequential so duplicate destinations can be detected
+  consistently.
+- If two plugins would copy to the same destination, the later plugin is
+  skipped and is not recorded in the lockfile.
 
-- Generate completion script for Fish: `pez completions fish > ~/.config/fish/completions/pez.fish`
-- Completions are intentionally Fish-only.
+## uninstall
 
-### activate
+```sh
+pez uninstall [OPTIONS] [PLUGINS]...
+```
 
-- Output shell activation code that wraps `pez` with hooks in the current shell.
-- Usage: `pez activate fish | source` (for persistence, add inside `if status is-interactive ... end` in `~/.config/fish/config.fish`).
-- Behavior: after `install`/`upgrade`, sources matching `conf.d` files and emits `<stem>_{install|update}` in the current shell; before `uninstall`, emits `<stem>_uninstall`.
-- Out-of-process event emits only run for safe stems (`A-Z`, `a-z`, `0-9`, `_`, `-`, or `.`); uninstall emits run only after cleanup and state updates succeed.
-- When active, the wrapper runs `pez` with `PEZ_SUPPRESS_EMIT=1` to avoid duplicate out-of-process emits.
+Removes plugin files recorded in `pez-lock.toml`, removes the cached repository
+when present, and removes the matching entry from `pez.toml`.
 
-### files
+Options:
 
-- List installed files recorded in `pez-lock.toml`.
-- Plugin identifiers: `owner/repo`, `host/owner/repo`, or URLs; `@ref` suffixes are accepted for shorthand/host forms and ignored for lookup.
-- Options:
-  - `--all` list files for all installed plugins.
-  - `--dir [conf.d|all]` filter destinations.
-  - `--format [paths|json]` output format.
-  - `--from [install|update|upgrade|uninstall|remove]` derive plugins by parsing a subcommand; pass the subcommand args after `--` (`update`/`remove` are aliases for `upgrade`/`uninstall`).
-- Examples:
-  - `pez files --all`
-  - `pez files owner/repo --dir conf.d`
-  - `pez files --from install -- owner/repo@v3`
-  - `printf "owner/a\n" | pez files --from uninstall -- --stdin`
+| Option | Meaning |
+| --- | --- |
+| `-f`, `--force` | Remove recorded files even if the cached repository is missing. |
+| `--stdin` | Read plugin repos from standard input, one per line. Blank lines and comments are ignored. |
 
-### migrate
+Example:
 
-- Import from fisher’s `fish_plugins` into `pez.toml`.
-- By default the command merges new repos into the existing `pez.toml`, skipping duplicates, ignoring comments/blank lines, and omitting the `jorgebucaran/fisher` entry itself.
-- Pinned refs such as `owner/repo@2.0.0`, `owner/repo@tag:v1`, or `host/owner/repo@branch:main` are preserved; if an entry was already pinned in `pez.toml`, migrating to a different ref updates it, while unpinned incoming entries leave the existing pin untouched. URL-based entries that append `@ref` as part of the URL or lines with an empty suffix (e.g. `owner/repo@`) are ignored to avoid writing invalid specs—convert them to `owner/repo@ref` form before migrating.
-- `--dry-run` prints the planned additions without modifying any files.
-- `--force` replaces the existing plugin list with the migrated entries instead of merging.
-- `--install` triggers `pez install` for the migrated entries after they are written (skipped when `--dry-run` is set).
-- The command always prints "Next steps" guidance (install/verify/doctor/activate flow) so you can continue migration safely.
-- Recommended migration flow is documented in [migrate-from-fisher.md](migrate-from-fisher.md).
+```sh
+printf "owner/a\nowner/b\n" | pez uninstall --stdin
+```
+
+## upgrade
+
+```sh
+pez upgrade [PLUGINS]...
+```
+
+Updates remote plugins. With no arguments, upgrades plugins listed in
+`pez.toml`. With arguments, upgrades the named repos and adds missing repos to
+`pez.toml` so future installs stay in sync.
+
+Rules:
+
+- Local path plugins are skipped.
+- `version`, `branch`, `tag`, and `commit` selectors in `pez.toml` are
+  respected.
+- Plugins without selectors update to the latest commit on the remote default
+  branch.
+- Work is bounded by `--jobs` or `PEZ_JOBS`.
+
+## list
+
+```sh
+pez list [OPTIONS]
+```
+
+Shows plugins recorded in `pez-lock.toml`.
+
+Options:
+
+| Option | Values | Meaning |
+| --- | --- | --- |
+| `--format` | `plain`, `table`, `json` | Output format. |
+| `--outdated` | | Compare remote plugins with their latest selected revision. |
+| `--filter` | `all`, `local`, `remote` | Filter by source kind. |
+
+Output fields:
+
+- Normal table/json: `name`, `repo`, `source`, `selector`, `commit`
+- Outdated table/json: `name`, `repo`, `source`, `current`, `latest`
+
+## prune
+
+```sh
+pez prune [OPTIONS]
+```
+
+Removes plugins that exist in `pez-lock.toml` but are no longer listed in
+`pez.toml`.
+
+Options:
+
+| Option | Meaning |
+| --- | --- |
+| `-f`, `--force` | Remove recorded files even if the cached repository is missing. |
+| `--dry-run` | Print what would be removed. |
+| `-y`, `--yes` | Confirm prompts. |
+
+If `pez.toml` has no plugin entries, `prune` asks for confirmation unless
+`--yes` is set.
+
+## doctor
+
+```sh
+pez doctor [--format json]
+```
+
+Checks setup state and reports common problems.
+
+Checks include config and lockfile readability, fish config/data directories,
+activation readiness, install layout, missing cached repos, missing target
+files, duplicate destinations, and theme assets.
+
+## files
+
+```sh
+pez files [OPTIONS] [PLUGINS]...
+```
+
+Lists installed files recorded in `pez-lock.toml`.
+
+Options:
+
+| Option | Values | Meaning |
+| --- | --- | --- |
+| `--all` | | List files for all installed plugins. |
+| `--dir` | `all`, `conf.d` | Filter by destination directory. Default: `all`. |
+| `--format` | `paths`, `json` | Output format. Default: `paths`. |
+| `--from` | `install`, `update`, `upgrade`, `uninstall`, `remove` | Parse plugin targets from another command's argv. |
+
+Examples:
+
+```sh
+pez files --all
+pez files owner/repo --dir conf.d
+pez files --from install -- owner/repo@v3
+printf "owner/a\n" | pez files --from uninstall -- --stdin
+```
+
+## completions
+
+```sh
+pez completions fish > ~/.config/fish/completions/pez.fish
+```
+
+Generates fish completions. Other shells are not supported.
+
+## activate
+
+```fish
+pez activate fish | source
+```
+
+Prints a fish wrapper for `pez` so install, upgrade, and uninstall hooks can run
+in the current shell.
+
+When active:
+
+- `install` and `upgrade` source affected `conf.d` files and emit
+  `<stem>_install` or `<stem>_update`.
+- `uninstall` emits `<stem>_uninstall` before running the raw uninstall command.
+- The wrapper sets `PEZ_SUPPRESS_EMIT=1` to avoid duplicate out-of-process
+  emits.
+
+Out-of-process emits only run for safe stems made from `A-Z`, `a-z`, `0-9`,
+`_`, `-`, and `.`.
+
+## migrate
+
+```sh
+pez migrate [OPTIONS]
+```
+
+Imports fisher's `fish_plugins` into `pez.toml`.
+
+Options:
+
+| Option | Meaning |
+| --- | --- |
+| `--dry-run` | Print the planned config changes without writing files. |
+| `--force` | Replace the current plugin list instead of merging into it. |
+| `--install` | Install migrated plugins immediately after writing `pez.toml`. |
+
+Migration skips `jorgebucaran/fisher`, ignores comments and blank lines, and
+preserves supported `@ref` suffixes from `fish_plugins`.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -67,10 +67,12 @@ Install behavior:
 - CLI relative paths and `~/` paths are normalized before they are saved.
 - Explicit remote targets clone concurrently, bounded by `--jobs` or `PEZ_JOBS`.
 - Config-driven installs run sequentially.
-- File copying is sequential so duplicate destinations can be detected
-  consistently.
-- If two plugins would copy to the same destination, the later plugin is
-  skipped and is not recorded in the lockfile.
+- File copying is sequential so run-level duplicate destinations can be
+  detected consistently.
+- If two plugins would copy to the same destination in one run, pez warns and
+  skips the later plugin's file copies. `pez-lock.toml` records only copied
+  files, so a fully skipped plugin can remain as an installed entry with an
+  empty `files` list.
 
 ## uninstall
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,7 +8,7 @@ Global options:
 
 | Option | Meaning |
 | --- | --- |
-| `-v`, `--verbose` | Increase log verbosity. Use `-vv` for debug logs. |
+| `-v`, `--verbose` | Log verbosity flag. Logs default to info; use `-vv` for debug logs. |
 | `--jobs <N>` | Override parallel work for explicit install clones, `upgrade`, `uninstall`, and `prune`. Must be at least 1. |
 | `-h`, `--help` | Print help. |
 | `-V`, `--version` | Print version. |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -67,12 +67,15 @@ Install behavior:
 - CLI relative paths and `~/` paths are normalized before they are saved.
 - Explicit remote targets clone concurrently, bounded by `--jobs` or `PEZ_JOBS`.
 - Config-driven installs run sequentially.
-- File copying is sequential so run-level duplicate destinations can be
-  detected consistently.
-- If two plugins would copy to the same destination in one run, pez warns and
-  skips the later plugin's file copies. `pez-lock.toml` records only copied
-  files, so a fully skipped plugin can remain as an installed entry with an
-  empty `files` list.
+- File copying is sequential for explicit CLI installs and for config-driven
+  installs when they copy a plugin already tracked in `pez-lock.toml`, so those
+  paths can detect run-level duplicate destinations consistently.
+- When that dedupe path finds a destination already claimed in the same run,
+  pez warns and skips the later plugin's file copies. `pez-lock.toml` records
+  only copied files, so a fully skipped plugin can remain as an installed entry
+  with an empty `files` list.
+- Fresh config-driven plugin entries are copied directly. Run `pez doctor`
+  after config-driven installs to inspect duplicate destination issues.
 
 ## uninstall
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,7 +8,7 @@ Global options:
 
 | Option | Meaning |
 | --- | --- |
-| `-v`, `--verbose` | Increase log verbosity. Logs default to info; use `-vv` for debug logs. |
+| `-v`, `--verbose` | Set log verbosity. Logs default to info; use `-vv` for debug logs. |
 | `--jobs <N>` | Set the number of parallel jobs for explicit install clones, `upgrade`, `uninstall`, and `prune`. Must be at least 1. |
 | `-h`, `--help` | Print help. |
 | `-V`, `--version` | Print version. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,10 +64,11 @@ Rules:
 
 - `repo = "owner/repo"` resolves to GitHub.
 - `repo = "host/owner/repo"` resolves to `https://host/owner/repo`.
-- `url` values without a scheme are normalized to `https://`.
-- SCP-style SSH remotes such as `git@host:owner/repo.git` are not valid
-  scheme-less `url` values in `pez.toml`; use
-  `ssh://git@host/owner/repo.git` or `repo = "host/owner/repo"` instead.
+- `url` values without a scheme are accepted and normalized to `https://`.
+- SCP-style SSH remotes such as `git@host:owner/repo.git` are accepted by the
+  parser but are not a supported scheme-less `url` form; they are normalized as
+  HTTPS URLs. Use `ssh://git@host/owner/repo.git` or
+  `repo = "host/owner/repo"` instead.
 - `path` values must be absolute or start with `~/` in `pez.toml`.
 - CLI installs may use relative paths; pez normalizes them before saving.
 - Unknown keys are rejected.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,6 +65,9 @@ Rules:
 - `repo = "owner/repo"` resolves to GitHub.
 - `repo = "host/owner/repo"` resolves to `https://host/owner/repo`.
 - `url` values without a scheme are normalized to `https://`.
+- SCP-style SSH remotes such as `git@host:owner/repo.git` are not valid
+  scheme-less `url` values in `pez.toml`; use
+  `ssh://git@host/owner/repo.git` or `repo = "host/owner/repo"` instead.
 - `path` values must be absolute or start with `~/` in `pez.toml`.
 - CLI installs may use relative paths; pez normalizes them before saving.
 - Unknown keys are rejected.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,10 +122,13 @@ pez copies only supported fish assets from top-level plugin directories:
 | `conf.d` | `.fish` files |
 | `themes` | `.theme` files |
 
-Subdirectories are preserved. Duplicate destination checks are run-level: if a
-later plugin would write a path already claimed earlier in the same run, pez
-skips that plugin's file copies. The plugin entry can still appear in
-`pez-lock.toml`, but copied files are not recorded for that plugin.
+Subdirectories are preserved. Explicit CLI installs, and config-driven installs
+when they copy a plugin already tracked in `pez-lock.toml`, use run-level
+duplicate destination checks: if a later plugin would write a path already
+claimed earlier in the same run, pez skips that plugin's file copies. The plugin
+entry can still appear in `pez-lock.toml`, but copied files are not recorded for
+that plugin. Fresh config-driven entries are copied directly; use `pez doctor`
+after install to inspect duplicate destination issues.
 
 ## Hooks and Activation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,7 +3,7 @@
 pez has two primary state files:
 
 - `pez.toml`: the plugin list you edit.
-- `pez-lock.toml`: the installed state pez writes.
+- `pez-lock.toml`: the installed state that pez writes.
 
 ## Locations
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,9 +122,10 @@ pez copies only supported fish assets from top-level plugin directories:
 | `conf.d` | `.fish` files |
 | `themes` | `.theme` files |
 
-Subdirectories are preserved. If two plugins would write the same destination
-path in one run, the later plugin is skipped and is not recorded in the
-lockfile.
+Subdirectories are preserved. Duplicate destination checks are run-level: if a
+later plugin would write a path already claimed earlier in the same run, pez
+skips that plugin's file copies. The plugin entry can still appear in
+`pez-lock.toml`, but copied files are not recorded for that plugin.
 
 ## Hooks and Activation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,95 +1,96 @@
 # Configuration and Lockfile
 
-This document describes the user‑facing configuration files used by pez.
+pez has two primary state files:
 
-## Locations and Precedence
+- `pez.toml`: the plugin list you edit.
+- `pez-lock.toml`: the installed state pez writes.
 
-- Config files (`pez.toml`, `pez-lock.toml`):
-  `PEZ_CONFIG_DIR` > `__fish_config_dir` > `XDG_CONFIG_HOME/fish` > `~/.config/fish`
-- Data directory (cloned repos):
-  `PEZ_DATA_DIR` > `__fish_user_data_dir/pez` > `XDG_DATA_HOME/fish/pez` > `~/.local/share/fish/pez`
-- Copy destination:
-  `PEZ_TARGET_DIR` > `__fish_config_dir` > `XDG_CONFIG_HOME/fish` > `~/.config/fish`
+## Locations
 
-`PEZ_TARGET_DIR` only affects where plugin files are copied; configuration and
-lock files always live under the config precedence above.
+| Purpose | Precedence |
+| --- | --- |
+| Config and lockfile | `PEZ_CONFIG_DIR` > `__fish_config_dir` > `XDG_CONFIG_HOME/fish` > `~/.config/fish` |
+| Cached Git repos | `PEZ_DATA_DIR` > `__fish_user_data_dir/pez` > `XDG_DATA_HOME/fish/pez` > `~/.local/share/fish/pez` |
+| Copied plugin files | `PEZ_TARGET_DIR` > `__fish_config_dir` > `XDG_CONFIG_HOME/fish` > `~/.config/fish` |
+
+`PEZ_TARGET_DIR` changes only where plugin files are copied. It does not move
+`pez.toml` or `pez-lock.toml`.
 
 ## pez.toml
 
-Define the plugins you want pez to manage. Each entry must specify exactly one
-source kind and at most one version selector.
+Each `[[plugins]]` entry uses exactly one source: `repo`, `url`, or `path`.
+Remote sources may use at most one selector: `version`, `branch`, `tag`, or
+`commit`.
 
-Rules
-
-- Source: choose exactly one of `repo` (GitHub shorthand), `url` (full Git URL), or `path` (local directory).
-- Selector: choose at most one of `version`, `branch`, `tag`, or `commit`.
-- Name (optional): set `name = "..."` to override the display name recorded in the lockfile and shown in `list`.
-
-GitHub shorthand (repo source)
+GitHub shorthand:
 
 ```toml
 [[plugins]]
 repo = "owner/repo"
-# version = "latest"   # default if omitted; or "v3" (branch preferred over tags)
-# branch  = "main"
-# tag     = "v1.2.3"
-# commit  = "<sha>"    # 7+ chars recommended
-#
-# Non-GitHub host example
-# [[plugins]]
-# repo = "gitlab.com/owner/repo"
-# version = "latest"
 ```
 
-Generic Git host (url source)
+Host-prefixed shorthand:
 
 ```toml
 [[plugins]]
-url = "https://gitlab.com/owner/repo"
-# version = "v3"
-# branch  = "main"
-# tag     = "v1.2.3"
-# commit  = "<sha>"
+repo = "gitlab.com/owner/repo"
+branch = "main"
 ```
 
-Local directory (path source)
+Full Git URL:
 
 ```toml
 [[plugins]]
-path = "~/path/to/local/plugin"   # absolute or ~/ only
+url = "https://example.com/owner/repo.git"
+tag = "v1.2.3"
 ```
 
-Notes
+Local path:
 
-- If a URL has no scheme, pez normalizes it to https (e.g., `gitlab.com/...`).
-- CLI‑provided relative paths and `~/` are normalized to absolute paths when recorded.
-- `path` must resolve to an absolute path (either absolute or `~/…`).
-- Host-prefixed repos (e.g., `gitlab.com/owner/repo`) are recorded as-is and cloned under `<host>/<owner>/<repo>` inside the data directory. GitHub shorthand (`owner/repo`) continues to map to `github.com`.
-- Unknown keys in `pez.toml` are rejected at load time.
-- `path` sources cannot include version selectors (`version`/`branch`/`tag`/`commit`).
-
-## JSON Schema
-
-`config.schema.json` provides a JSON Schema representation of the `pez.toml`
-plugin spec rules.
-
-Regenerate it with:
-
-```sh
-cargo run --features schema-gen --bin gen-config-schema
+```toml
+[[plugins]]
+path = "~/plugins/local-plugin"
 ```
 
-When changing config-related types or validation rules, regenerate
-`config.schema.json` and include the updated file in the same commit.
+Custom display name:
+
+```toml
+[[plugins]]
+name = "prompt"
+repo = "owner/fish-prompt"
+```
+
+Rules:
+
+- `repo = "owner/repo"` resolves to GitHub.
+- `repo = "host/owner/repo"` resolves to `https://host/owner/repo`.
+- `url` values without a scheme are normalized to `https://`.
+- `path` values must be absolute or start with `~/` in `pez.toml`.
+- CLI installs may use relative paths; pez normalizes them before saving.
+- Unknown keys are rejected.
+- `path` sources cannot use selectors.
+
+## Selectors
+
+| Field | Meaning |
+| --- | --- |
+| `version = "v3"` | Branch-or-tag version selector. Branches are preferred over tags. Semver tag prefixes are supported. |
+| `version = "latest"` | Remote default branch. |
+| `branch = "main"` | Named branch. |
+| `tag = "v1.2.3"` | Exact tag. |
+| `commit = "<sha>"` | Exact commit. |
+
+When no selector is set, install and upgrade use the remote default branch.
 
 ## pez-lock.toml
 
-Machine‑generated; do not edit. The lock file records the concrete state pez has
-installed: `name`, `repo`, `source`, `commit_sha`, and copied `files`.
+`pez-lock.toml` is generated. Do not edit it manually.
 
-Example
+It records the installed plugin name, repo identifier, source URL or local path,
+installed commit, and copied files:
 
 ```toml
+# This file is automatically generated by pez. Do not edit it manually.
 version = 1
 
 [[plugins]]
@@ -107,38 +108,73 @@ commit_sha = "abc1234..."
   name = "bar.fish"
 ```
 
-Notes
+Local plugins use `commit_sha = "local"`. They are skipped by `upgrade` and
+excluded from outdated comparisons.
 
-- For local sources, `commit_sha = "local"`. Such entries are skipped by
-  `upgrade` and excluded from `list --outdated` comparisons.
+## Copy Rules
 
-## Plugin Layout and Copy Rules
+pez copies only supported fish assets from top-level plugin directories:
 
-- pez looks for top-level `functions`, `completions`, `conf.d`, and `themes` directories in each plugin repo.
-- It copies files recursively into the matching Fish config directories, preserving relative paths.
-- Only `.fish` files are copied from `functions`/`completions`/`conf.d`, and only `.theme` files from `themes`.
-- If two plugins would write the same destination path in a single run, the later plugin is skipped and its files are not recorded in the lockfile.
-- For `conf.d` files with safe stems (`A-Z`, `a-z`, `0-9`, `_`, `-`, or `.`), pez emits out-of-process `<stem>_{install|update|uninstall}` events unless `PEZ_SUPPRESS_EMIT` is set. Raw uninstall emits run only after cleanup and state updates succeed; the activation wrapper sources and emits uninstall hooks before running `pez uninstall` in the current shell.
+| Source directory | Copied files |
+| --- | --- |
+| `functions` | `.fish` files |
+| `completions` | `.fish` files |
+| `conf.d` | `.fish` files |
+| `themes` | `.theme` files |
 
-## Environment Variables and CLI Overrides
+Subdirectories are preserved. If two plugins would write the same destination
+path in one run, the later plugin is skipped and is not recorded in the
+lockfile.
 
-- `PEZ_CONFIG_DIR` — Directory containing `pez.toml` and `pez-lock.toml`.
-- `PEZ_DATA_DIR` — Base directory for cloned plugin repositories.
-- `PEZ_TARGET_DIR` — Override the Fish config directory used for copying plugin files. It no longer changes where `pez.toml` or `pez-lock.toml` live.
-- `PEZ_SUPPRESS_EMIT` — When set, suppress out-of-process fish event hooks during install/upgrade/uninstall. Used by `pez activate fish` to avoid duplicate events.
-- `__fish_config_dir` / `XDG_CONFIG_HOME` — Fish configuration directory.
-- `__fish_user_data_dir` / `XDG_DATA_HOME` — Fish data directory.
-- `--jobs <N>` — Global CLI flag to override concurrency for `install` (explicit
-  targets), `upgrade`, `uninstall`, and `prune`. Must be a positive integer.
-- `PEZ_JOBS` — Environment override for the same concurrency (default: 4). Ignored
-  when `--jobs` is provided.
-- `RUST_LOG` — Log filtering (takes precedence over `-v`).
+## Hooks and Activation
 
-### Migration Note (PEZ_TARGET_DIR)
+For `conf.d` files with safe stems, pez emits fish events:
 
-Releases after September 16, 2025 keep configuration files under the config
-precedence `PEZ_CONFIG_DIR` → `__fish_config_dir` → `XDG_CONFIG_HOME/fish` →
-`~/.config/fish`, even when `PEZ_TARGET_DIR` is set. If your existing
-`pez.toml` or `pez-lock.toml` live in a path referenced solely by
-`PEZ_TARGET_DIR`, move them into a directory referenced by `PEZ_CONFIG_DIR`
-or set `PEZ_CONFIG_DIR` to that path before invoking pez.
+- `<stem>_install`
+- `<stem>_update`
+- `<stem>_uninstall`
+
+Safe stems may contain `A-Z`, `a-z`, `0-9`, `_`, `-`, and `.`.
+
+Without activation, these events are emitted out of process. Source
+`pez activate fish` when plugins need hooks to affect the current shell:
+
+```fish
+pez activate fish | source
+```
+
+The activation wrapper sets `PEZ_SUPPRESS_EMIT=1` to avoid duplicate events.
+
+## Environment Variables
+
+| Variable | Meaning |
+| --- | --- |
+| `PEZ_CONFIG_DIR` | Directory for `pez.toml` and `pez-lock.toml`. |
+| `PEZ_DATA_DIR` | Base directory for cached plugin repositories. |
+| `PEZ_TARGET_DIR` | Destination fish config directory for copied plugin files. |
+| `PEZ_SUPPRESS_EMIT` | Suppress out-of-process hook emits. Used by activation. |
+| `PEZ_JOBS` | Default parallel job count when `--jobs` is not set. |
+| `RUST_LOG` | Log filtering. Takes precedence over `-v`. |
+
+fish and XDG variables also participate in path resolution:
+`__fish_config_dir`, `__fish_user_data_dir`, `XDG_CONFIG_HOME`, and
+`XDG_DATA_HOME`.
+
+## JSON Schema
+
+`config.schema.json` describes the `pez.toml` shape.
+
+Regenerate it after config model changes:
+
+```sh
+cargo run --features schema-gen --bin gen-config-schema
+```
+
+Include the schema update in the same change as the model change.
+
+## PEZ_TARGET_DIR Migration Note
+
+Modern pez releases keep `pez.toml` and `pez-lock.toml` under the config
+precedence even when `PEZ_TARGET_DIR` is set. If older local state lives only
+under `PEZ_TARGET_DIR`, move it to `PEZ_CONFIG_DIR` or set `PEZ_CONFIG_DIR` to
+that location before running pez.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -37,8 +37,9 @@ Check whether the plugin has a selector in `pez.toml`.
 
 ## How are duplicate files handled?
 
-If two plugins would write the same destination path in one run, the later
-plugin is skipped and is not recorded in `pez-lock.toml`.
+If two plugins would write the same destination path in one run, pez skips the
+later plugin's file copies. The plugin can still appear in `pez-lock.toml`;
+only copied files are recorded, so that entry may have an empty `files` list.
 
 Use `pez doctor` to inspect duplicate destination issues.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -27,7 +27,7 @@ pez copies files. fish decides when they load.
 If a plugin needs a specific order, manage that through fish configuration or
 plugin filenames.
 
-## Why did upgrade not move a plugin?
+## Why wasn't a plugin upgraded?
 
 Check whether the plugin has a selector in `pez.toml`.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -37,9 +37,13 @@ Check whether the plugin has a selector in `pez.toml`.
 
 ## How are duplicate files handled?
 
-If two plugins would write the same destination path in one run, pez skips the
-later plugin's file copies. The plugin can still appear in `pez-lock.toml`;
-only copied files are recorded, so that entry may have an empty `files` list.
+Explicit CLI installs, and config-driven installs when they copy a plugin
+already tracked in `pez-lock.toml`, check duplicate destinations within the
+current run. If a later plugin would write a claimed path, pez skips that
+plugin's file copies. The plugin can still appear in `pez-lock.toml`; only
+copied files are recorded, so that entry may have an empty `files` list.
+
+Fresh config-driven entries are copied directly.
 
 Use `pez doctor` to inspect duplicate destination issues.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,41 +1,114 @@
-## FAQ
+# FAQ
 
-### Where does pez put files?
+## Where does pez put plugin files?
 
-pez copies plugin files into your Fish config directory (`functions`, `completions`, `conf.d`, `themes`). See docs/configuration.md for directory precedence.
+By default, pez copies files into the fish config directory:
+`functions`, `completions`, `conf.d`, and `themes`.
 
-### How is load order determined?
+Use `PEZ_TARGET_DIR` to override the copy destination. See
+[configuration](configuration.md) for full path precedence.
 
-pez only copies files into the Fish config directories; Fish determines when and how they are loaded. If you need a specific order, manage it in your Fish configuration.
+## Where are repositories cloned?
 
-### Where are plugin repos cloned?
+Under the pez data directory. The default is `~/.local/share/fish/pez`.
 
-Under the pez data directory (by default `~/.local/share/fish/pez`). You can override via `PEZ_DATA_DIR`.
+Use `PEZ_DATA_DIR` to override it.
 
-### Why doesn't `upgrade` change my plugin pinned by tag/branch in pez.toml?
+## What does the lockfile track?
 
-`upgrade` respects selectors defined in `pez.toml`. If you pin a plugin to a specific `branch`, `tag`, `commit`, or `version`, `upgrade` resolves against that selector. When no selector is set, `upgrade` updates to the latest commit on the remote default branch (remote HEAD).
+`pez-lock.toml` records each installed plugin's name, repo identifier, source,
+installed commit, and copied files. Commands such as `uninstall`, `prune`,
+`doctor`, and `files` use it as the installed-state record.
 
-### How are duplicates handled when copying files?
+## How is load order determined?
 
-- Duplicate destination paths are detected for both CLI targets and installs from `pez.toml`. Conflicting plugins are skipped with a warning to avoid overwriting existing files.
+pez copies files. fish decides when they load.
 
-### How do I list the files installed by a plugin?
+If a plugin needs a specific order, manage that through fish configuration or
+plugin filenames.
 
-Use `pez files owner/repo` for a single plugin or `pez files --all` for everything. Add `--dir conf.d` to filter to conf.d scripts.
+## Why did upgrade not move a plugin?
 
-### How do I run conf.d hooks in my current shell?
+Check whether the plugin has a selector in `pez.toml`.
 
-Source the activation script: `pez activate fish | source`. For persistence, place it in `~/.config/fish/config.fish` inside `if status is-interactive ... end`. This wraps `pez` so `install`/`upgrade`/`uninstall` source the affected conf.d files and emit events in the current shell.
+- `branch`, `tag`, `commit`, and `version` selectors are respected.
+- Local path plugins are skipped.
+- Unpinned remote plugins update to the remote default branch.
 
-### How do I uninstall everything not in pez.toml?
+## How are duplicate files handled?
 
-Run `pez prune`. Use `--dry-run` to preview and `--yes` to skip confirmation when `pez.toml` has no `[[plugins]]` entries.
+If two plugins would write the same destination path in one run, the later
+plugin is skipped and is not recorded in `pez-lock.toml`.
 
-### How do I use a local plugin?
+Use `pez doctor` to inspect duplicate destination issues.
 
-Add `[[plugins]] path = "~/path/to/plugin"`. Local sources are not upgraded and are excluded from `list --outdated`.
+## How do I see what a plugin installed?
 
-### I installed the same repo twice with a different name — is that supported?
+```sh
+pez files owner/repo
+pez files owner/repo --dir conf.d
+pez files --all
+```
 
-Not supported: `pez.toml` entries are unique by repo, and the lockfile also enforces unique source/name. Prefer a single install per repo. If you need a custom display name, set `name = "..."` in the plugin spec.
+Use `--format json` for machine-readable output.
+
+## How do I run conf.d hooks in the current shell?
+
+Source activation:
+
+```fish
+pez activate fish | source
+```
+
+For persistence:
+
+```fish
+if status is-interactive
+    pez activate fish | source
+end
+```
+
+This wraps `pez` so install, upgrade, and uninstall hooks can affect the current
+shell.
+
+## How do I remove plugins no longer listed in pez.toml?
+
+Preview first:
+
+```sh
+pez prune --dry-run
+```
+
+Then prune:
+
+```sh
+pez prune
+```
+
+Use `--yes` to confirm prompts in scripts.
+
+## How do I use a local plugin?
+
+In `pez.toml`:
+
+```toml
+[[plugins]]
+path = "~/plugins/local-plugin"
+```
+
+Or from the CLI:
+
+```sh
+pez install ./local-plugin
+```
+
+CLI relative paths are saved as absolute paths. Local plugins are skipped by
+`upgrade` and excluded from `list --outdated`.
+
+## Can I install the same repo twice?
+
+Not as separate managed entries. `pez.toml` is unique by repo, and
+`pez-lock.toml` rejects duplicate source or name entries.
+
+Use one entry per repo. Set `name = "..."` only when you need a different
+display name.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,7 @@
 # Getting Started
 
-This guide gets from a new `pez.toml` to an installed, inspectable fish plugin
-setup.
+This guide takes you from a new `pez.toml` to an installed, inspectable fish
+plugin setup.
 
 ## 1. Create the config file
 
@@ -114,5 +114,5 @@ end
 | Diagnose setup state | `pez doctor` |
 | Remove lockfile-only plugins | `pez prune --dry-run` |
 
-Logs default to info. Use `-vv` for debug logs. Use `--jobs <N>` to override
-parallel work where the command supports it.
+Logs default to info. Use `-vv` for debug logs. Use `--jobs <N>` to set the
+number of parallel jobs where the command supports it.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,70 +1,118 @@
-## Getting started
+# Getting Started
 
-### Quick start
+This guide gets from a new `pez.toml` to an installed, inspectable fish plugin
+setup.
 
-1) Initialize configuration (creates `pez.toml`)
+## 1. Create the config file
 
-```shell
+```sh
 pez init
 ```
 
-2) Add a plugin to `pez.toml` (choose one of repo/url/path)
+`pez.toml` is created under the fish config directory unless `PEZ_CONFIG_DIR`
+overrides it.
+
+## 2. Add plugins
+
+Use one source per plugin.
+
+GitHub shorthand:
 
 ```toml
 [[plugins]]
-repo = "owner/repo"      # GitHub shorthand
-# version = "v3"        # Or: tag = "...", branch = "...", commit = "..."
-
-## Or a full Git URL
-# [[plugins]]
-# url = "https://gitlab.com/owner/repo"
-# branch = "main"
-
-## Or a local directory (absolute or ~/ only)
-# [[plugins]]
-# path = "~/path/to/local/plugin"
+repo = "owner/repo"
 ```
 
-3) Install and list
+Another Git host:
 
-```shell
+```toml
+[[plugins]]
+repo = "gitlab.com/owner/repo"
+branch = "main"
+```
+
+Full Git URL:
+
+```toml
+[[plugins]]
+url = "https://example.com/owner/repo"
+tag = "v1.2.3"
+```
+
+Local directory:
+
+```toml
+[[plugins]]
+path = "~/plugins/local-plugin"
+```
+
+Selectors are optional. Use at most one of `version`, `branch`, `tag`, or
+`commit`.
+
+## 3. Install and verify
+
+```sh
 pez install
 pez list --format table
+pez doctor
 ```
 
-4) Optional: enable completions for pez itself
+`pez install` copies supported fish assets into the target fish config
+directories and records installed files in `pez-lock.toml`.
 
-```shell
+## 4. Install directly from the CLI
+
+CLI installs also update `pez.toml`, so future `pez install` runs remain in
+sync.
+
+```sh
+pez install owner/repo
+pez install owner/repo@v3
+pez install gitlab.com/owner/repo@branch:main
+pez install https://example.com/owner/repo.git
+pez install ./local-plugin
+```
+
+For shorthand targets, plain `@ref` is treated as `version`. Use
+`@branch:name`, `@tag:name`, or `@commit:sha` when the selector type matters.
+Full URLs are not parsed for `@ref`; put selectors in `pez.toml` for URL
+sources.
+
+## 5. Enable optional shell integration
+
+Completions:
+
+```sh
 pez completions fish > ~/.config/fish/completions/pez.fish
 ```
 
-Completions are intentionally Fish-only.
+Current-shell activation for `conf.d` hooks:
 
-5) Optional: enable fish shell hooks (conf.d events) for the current shell
-
-```shell
+```fish
 pez activate fish | source
 ```
 
-To persist, add it inside an `if status is-interactive ... end` block in `~/.config/fish/config.fish`.
+To persist activation, add it to `~/.config/fish/config.fish` inside an
+interactive-shell guard:
 
-### CLI usage (examples)
+```fish
+if status is-interactive
+    pez activate fish | source
+end
+```
 
-| Command | Purpose | Example |
-| --- | --- | --- |
-| `pez init` | Create `pez.toml` | `pez init` |
-| `pez install` | Install from `pez.toml` | `pez install` |
-| `pez install <target>` | Install a specific plugin | `pez install owner/repo@v3` |
-| `pez uninstall <repo>` | Uninstall a plugin | `pez uninstall owner/repo` |
-| `pez upgrade` | Update non‑local plugins to remote HEAD | `pez upgrade` |
-| `pez list --outdated` | Show outdated plugins | `pez list --outdated --format json` |
-| `pez doctor` | Run diagnostics | `pez doctor --format json` |
-| `pez activate fish` | Enable fish shell hooks | `pez activate fish | source` |
-| `pez files --all` | List installed files | `pez files --all` |
+## Daily Commands
 
-Key flag: `-v/--verbose` increases logging (`-vv` enables debug).
+| Task | Command |
+| --- | --- |
+| Install configured plugins | `pez install` |
+| Install one plugin | `pez install owner/repo` |
+| Update plugins | `pez upgrade` |
+| Show installed plugins | `pez list --format table` |
+| Show outdated remote plugins | `pez list --outdated --format table` |
+| Show installed files | `pez files --all` |
+| Diagnose setup state | `pez doctor` |
+| Remove lockfile-only plugins | `pez prune --dry-run` |
 
-### Notes
-
-- Selectors (version/branch/tag/commit) are honored across installs and by `upgrade`. When no selector is set, `upgrade` updates to the latest commit on the remote default branch (remote HEAD).
-- Duplicate destination paths are detected for both CLI targets and installs from `pez.toml`. Conflicting plugins are skipped with a warning to avoid overwriting existing files.
+Use `-v` for info logs and `-vv` for debug logs. Use `--jobs <N>` to override
+parallel work where the command supports it.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -114,5 +114,5 @@ end
 | Diagnose setup state | `pez doctor` |
 | Remove lockfile-only plugins | `pez prune --dry-run` |
 
-Use `-v` for info logs and `-vv` for debug logs. Use `--jobs <N>` to override
+Logs default to info. Use `-vv` for debug logs. Use `--jobs <N>` to override
 parallel work where the command supports it.

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,7 +4,8 @@
 
 - A prebuilt `pez` binary does not require Cargo.
 - Cargo is required for `cargo install` and source builds.
-- fish is required to use installed fish plugins and to source activation code.
+- The fish shell is required to use installed plugins and to source the
+  activation code.
 - Nix is optional.
 
 ## Install a Release Binary

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,16 +10,19 @@
 ## Install a Release Binary
 
 Download the asset for your platform from
-[GitHub Releases](https://github.com/tetzng/pez/releases), make it executable,
-and place it on your `PATH`.
+[GitHub Releases](https://github.com/tetzng/pez/releases). Release assets may
+be archives, so extract the downloaded file first, then make the `pez` binary
+executable and place it on your `PATH`.
 
 ```sh
-chmod +x pez
-./pez --version
+tar -xf pez-*.tar.*
+chmod +x path/to/pez
+path/to/pez --version
 ```
 
 Asset names vary by release and platform, so use the release page as the source
-of truth.
+of truth. Use the archive layout from the extracted asset when replacing
+`path/to/pez`.
 
 ## Install with Cargo
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,19 +10,26 @@
 ## Install a Release Binary
 
 Download the asset for your platform from
-[GitHub Releases](https://github.com/tetzng/pez/releases). Release assets may
-be archives, so extract the downloaded file first, then make the `pez` binary
-executable and place it on your `PATH`.
+[GitHub Releases](https://github.com/tetzng/pez/releases). Release assets are
+platform archives, so extract the downloaded file first.
+
+For macOS and Linux `.tar.xz` assets:
 
 ```sh
-tar -xf pez-*.tar.*
-chmod +x path/to/pez
-path/to/pez --version
+tar -xf pez-<target>.tar.xz
+chmod +x pez
+./pez --version
+```
+
+For Windows `.zip` assets in PowerShell:
+
+```powershell
+Expand-Archive .\pez-<target>.zip -DestinationPath .\pez-release
+.\pez-release\pez.exe --version
 ```
 
 Asset names vary by release and platform, so use the release page as the source
-of truth. Use the archive layout from the extracted asset when replacing
-`path/to/pez`.
+of truth. After verification, place `pez` or `pez.exe` on your `PATH`.
 
 ## Install with Cargo
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,88 +1,99 @@
-## Install & build
+# Install and Build
 
-### System requirements
+## Requirements
 
-- No mandatory external tools are required when using a prebuilt `pez` binary.
-- Cargo is required only for `cargo install` or local source builds.
-- Fish is required only for actually using installed Fish plugins.
+- A prebuilt `pez` binary does not require Cargo.
+- Cargo is required for `cargo install` and source builds.
+- fish is required to use installed fish plugins and to source activation code.
+- Nix is optional.
 
-### Install
+## Install a Release Binary
 
-Install with Cargo (from crates.io if available):
+Download the asset for your platform from
+[GitHub Releases](https://github.com/tetzng/pez/releases), make it executable,
+and place it on your `PATH`.
 
-```shell
+```sh
+chmod +x pez
+./pez --version
+```
+
+Asset names vary by release and platform, so use the release page as the source
+of truth.
+
+## Install with Cargo
+
+When the crate is published to crates.io:
+
+```sh
 cargo install pez
 ```
 
-From source (this repo):
+From this repository checkout:
 
-```shell
+```sh
 cargo install --path .
 ```
 
-From GitHub Releases (prebuilt binary, when available):
+## Run with Nix
 
-```shell
-# Visit the Releases page and download the asset for your platform.
-# Example (Linux x86_64):
-curl -fsSL -o pez https://github.com/<owner>/<repo>/releases/download/<tag>/pez-<tag>-linux-amd64
-chmod +x pez
-./pez -V
-```
-
-With Nix flakes:
-
-```shell
+```sh
 nix run github:tetzng/pez -- --version
 ```
 
-Notes
+If flakes are not enabled globally:
 
-- On tagged releases (`v*.*.*`), CI builds, tests, and uploads release artifacts.
-- Asset filenames vary by platform; check the release page for the exact names.
-- Nix flake commands require flakes to be enabled. If they are not enabled
-  globally, run them as
-  `nix --extra-experimental-features 'nix-command flakes' <subcommand> ...`.
+```sh
+nix --extra-experimental-features 'nix-command flakes' run github:tetzng/pez -- --version
+```
 
-### Build from source
+## Build from Source
 
-```shell
+```sh
 cargo build --release
-./target/release/pez -V
+./target/release/pez --version
 ```
 
-With Nix flakes:
+With Nix:
 
-```shell
+```sh
 nix build .#
-./result/bin/pez -V
+./result/bin/pez --version
 ```
 
-### Development shell
+## Development Shell
 
-Enter the Nix development environment:
-
-```shell
+```sh
 nix develop .#
 ```
 
-This provides the Rust toolchain, `rustfmt`, `clippy`, and Fish for local
-development from the pinned Nix flake input. It does not read
-`rust-toolchain.toml`; use rustup outside Nix when you need that file to select
-the toolchain exactly.
+The Nix shell provides the Rust toolchain, `rustfmt`, `clippy`, and fish from
+the pinned flake input. Outside Nix, use your normal Rust toolchain.
 
-### Shell completions
+## Shell Files
 
-```shell
+Install completions:
+
+```sh
 pez completions fish > ~/.config/fish/completions/pez.fish
 ```
 
-Completions are intentionally Fish-only.
+Activate current-shell hooks:
 
-### Shell activation
-
-```shell
+```fish
 pez activate fish | source
 ```
 
-To persist, add it inside an `if status is-interactive ... end` block in `~/.config/fish/config.fish`.
+Persist activation from `~/.config/fish/config.fish`:
+
+```fish
+if status is-interactive
+    pez activate fish | source
+end
+```
+
+## Release Notes for Maintainers
+
+Tagged `v*.*.*` releases are built by CI and distributed through GitHub
+Releases. Do not hand-edit cargo-dist generated workflow output; change the
+generator configuration instead.

--- a/docs/migrate-from-fisher.md
+++ b/docs/migrate-from-fisher.md
@@ -36,7 +36,8 @@ pez doctor
 
 ## Faster Flow
 
-Use `--install` when you want migration and install in one command:
+Use `--install` when `pez migrate --dry-run` shows entries that do not need
+manual edits before install:
 
 ```fish
 pez activate fish | source
@@ -84,8 +85,8 @@ Use `--force` only when you want the imported list to replace the current
   them to shorthand form or write explicit `url` entries in `pez.toml`.
 - SCP-style SSH entries such as `git@host:owner/repo.git` can be imported, but
   `pez.toml` treats scheme-less `url` values as HTTPS. Before running
-  `pez install`, convert them to `ssh://git@host/owner/repo.git` or
-  `repo = "host/owner/repo"`.
+  `pez install` or `pez migrate --install`, convert them to
+  `ssh://git@host/owner/repo.git` or `repo = "host/owner/repo"`.
 
 ## Rollback
 

--- a/docs/migrate-from-fisher.md
+++ b/docs/migrate-from-fisher.md
@@ -1,57 +1,71 @@
-# Migrate from fisher to pez
+# Migrate from fisher
 
-This guide provides a low-risk migration path from `fisher` to `pez`.
+pez can import fisher's `fish_plugins` into `pez.toml`. Keep the migration
+reversible until `pez doctor` reports a setup you trust.
 
-## Recommended path
+## Recommended Flow
 
-1. Enable activation in your current shell.
+1. Back up your fish config.
+2. Enable current-shell activation.
 
 ```fish
 pez activate fish | source
 ```
 
-2. Import `fish_plugins` into `pez.toml`.
+3. Preview the import.
+
+```fish
+pez migrate --dry-run
+```
+
+4. Import `fish_plugins`.
 
 ```fish
 pez migrate
 ```
 
-3. Install migrated plugins.
+5. Install and verify.
 
 ```fish
 pez install
-```
-
-4. Verify the result.
-
-```fish
 pez list --format table
 pez doctor
 ```
 
-5. Remove or disable fisher after verification.
+6. Remove or disable fisher only after verification.
 
-## Common pitfalls
+## Faster Flow
 
-- `pez activate fish` is not enabled:
-  `install`/`upgrade`/`uninstall` complete, but in-process `conf.d` events are not emitted in the current shell.
-- `fisher` itself was removed during migration:
-  this is expected; `jorgebucaran/fisher` is skipped by `pez migrate`.
-- `conf.d` behavior differs before activation:
-  without activation wrapper, hooks are emitted out-of-process and may not affect the current interactive shell session.
+Use `--install` when you want migration and install in one command:
 
-## What pez handles (and does not)
+```fish
+pez activate fish | source
+pez migrate --install
+pez list --format table
+pez doctor
+```
 
-- Handled:
-  - Reads `fish_plugins`, ignores blank/comment lines, and merges entries into `pez.toml`.
-  - Copies plugin assets from `functions`, `completions`, `conf.d`, `themes`.
-  - Tracks installed files and commits in `pez-lock.toml`.
-- Not handled automatically:
-  - Editing your `config.fish` to persist activation.
-  - Removing fisher from your shell config.
-  - Recovering custom manual edits in plugin-managed files.
+## What migrate does
 
-## fisher and pez command mapping
+- Reads fisher's `fish_plugins`.
+- Ignores blank lines and comments.
+- Skips `jorgebucaran/fisher`.
+- Merges imported entries into `pez.toml` by default.
+- Preserves supported ref suffixes such as `owner/repo@2.0.0`,
+  `owner/repo@tag:v1`, `owner/repo@branch:main`, and
+  `owner/repo@commit:<sha>`.
+
+Use `--force` only when you want the imported list to replace the current
+`pez.toml` plugin list.
+
+## What migrate does not do
+
+- It does not edit `config.fish` to persist activation.
+- It does not remove fisher from your shell config.
+- It does not recover manual edits inside plugin-managed files.
+- It does not sandbox or verify plugin code.
+
+## Command Mapping
 
 | fisher | pez |
 | --- | --- |
@@ -59,19 +73,32 @@ pez doctor
 | `fisher remove owner/repo` | `pez uninstall owner/repo` |
 | `fisher update` | `pez upgrade` |
 | `fisher list` | `pez list --format table` |
-| `fisher` diagnostics (manual checks) | `pez doctor` |
+| Manual checks | `pez doctor` |
+
+## Common Pitfalls
+
+- Without `pez activate fish | source`, install and upgrade still run, but
+  hooks may not affect the current interactive shell.
+- fisher itself being absent from `pez.toml` is expected. `pez migrate` skips it.
+- URL-style fisher entries with ambiguous `@ref` suffixes may be ignored. Convert
+  them to shorthand form or write explicit `url` entries in `pez.toml`.
 
 ## Rollback
 
-If you want to go back to fisher:
+1. Keep the backed-up fisher files until the migration is verified.
+2. Remove migrated entries from `pez.toml`, or uninstall the migrated repos
+   explicitly.
 
-1. Keep a backup of current `pez.toml` and `pez-lock.toml`.
-2. Remove pez-managed plugin files if needed:
+```fish
+pez uninstall owner/repo
+```
+
+3. If you removed entries from `pez.toml`, prune the lockfile-only plugins.
 
 ```fish
 pez prune --force --yes
 ```
 
-3. Remove or comment out `pez activate fish` from `config.fish`.
-4. Reinstall and re-enable fisher.
-5. Restore `fish_plugins` from backup and run fisher install flow.
+4. Remove or comment out `pez activate fish` from `config.fish`.
+5. Re-enable fisher.
+6. Restore `fish_plugins` from backup and run fisher's install flow.

--- a/docs/migrate-from-fisher.md
+++ b/docs/migrate-from-fisher.md
@@ -84,9 +84,10 @@ Use `--force` only when you want the imported list to replace the current
 - URL-style fisher entries with ambiguous `@ref` suffixes may be ignored. Convert
   them to shorthand form or write explicit `url` entries in `pez.toml`.
 - SCP-style SSH entries such as `git@host:owner/repo.git` can be imported, but
-  `pez.toml` treats scheme-less `url` values as HTTPS. Before running
-  `pez install` or `pez migrate --install`, convert them to
-  `ssh://git@host/owner/repo.git` or `repo = "host/owner/repo"`.
+  `pez.toml` accepts scheme-less `url` values by normalizing them as HTTPS, not
+  as SCP-style SSH remotes. Before running `pez install` or
+  `pez migrate --install`, convert them to `ssh://git@host/owner/repo.git` or
+  `repo = "host/owner/repo"`.
 
 ## Rollback
 

--- a/docs/migrate-from-fisher.md
+++ b/docs/migrate-from-fisher.md
@@ -82,6 +82,10 @@ Use `--force` only when you want the imported list to replace the current
 - fisher itself being absent from `pez.toml` is expected. `pez migrate` skips it.
 - URL-style fisher entries with ambiguous `@ref` suffixes may be ignored. Convert
   them to shorthand form or write explicit `url` entries in `pez.toml`.
+- SCP-style SSH entries such as `git@host:owner/repo.git` can be imported, but
+  `pez.toml` treats scheme-less `url` values as HTTPS. Before running
+  `pez install`, convert them to `ssh://git@host/owner/repo.git` or
+  `repo = "host/owner/repo"`.
 
 ## Rollback
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A Rust-based plugin manager for fish";
+  description = "A lockfile-backed plugin manager for fish";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,7 @@ fn parse_jobs_override(raw: &str) -> Result<usize, String> {
 #[derive(Parser, Debug)]
 #[command(name = "pez", version, about, long_about = None)]
 pub(crate) struct Cli {
-    /// Increase output verbosity (-v for info, -vv for debug)
+    /// Log verbosity flag (default info; -vv enables debug)
     #[arg(short, long, action = clap::ArgAction::Count, global = true)]
     pub(crate) verbose: u8,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,7 @@ fn parse_jobs_override(raw: &str) -> Result<usize, String> {
 #[derive(Parser, Debug)]
 #[command(name = "pez", version, about, long_about = None)]
 pub(crate) struct Cli {
-    /// Increase log verbosity (default: info; -vv enables debug logs)
+    /// Set log verbosity (default: info; -vv enables debug logs)
     #[arg(short, long, action = clap::ArgAction::Count, global = true)]
     pub(crate) verbose: u8,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,11 +16,11 @@ fn parse_jobs_override(raw: &str) -> Result<usize, String> {
 #[derive(Parser, Debug)]
 #[command(name = "pez", version, about, long_about = None)]
 pub(crate) struct Cli {
-    /// Log verbosity flag (default info; -vv enables debug)
+    /// Increase log verbosity (default: info; -vv enables debug logs)
     #[arg(short, long, action = clap::ArgAction::Count, global = true)]
     pub(crate) verbose: u8,
 
-    /// Override job concurrency for explicit install clones, upgrade, uninstall, and prune (default: 4 when unset)
+    /// Set the number of parallel jobs for explicit install clones, upgrade, uninstall, and prune (default: 4 when unset)
     #[arg(long, value_name = "N", value_parser = parse_jobs_override, global = true)]
     pub(crate) jobs: Option<usize>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,7 +20,7 @@ pub(crate) struct Cli {
     #[arg(short, long, action = clap::ArgAction::Count, global = true)]
     pub(crate) verbose: u8,
 
-    /// Set the number of parallel jobs for explicit install clones, upgrade, uninstall, and prune (default: 4 when unset)
+    /// Set the number of parallel jobs for explicit install clones, upgrade, uninstall, and prune (default: PEZ_JOBS, falling back to 4)
     #[arg(long, value_name = "N", value_parser = parse_jobs_override, global = true)]
     pub(crate) jobs: Option<usize>,
 

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -18,22 +18,26 @@ fn create_config(config_dir: &path::Path) -> anyhow::Result<()> {
         anyhow::bail!("{} already exists", config_path.display());
     }
 
-    let contents = r#"# This file defines the plugins to be installed by pez.
-
-# Examples of plugins:
-# [[plugins]]
-# repo = "owner/repo"      # GitHub shorthand
-# # version = "v3"        # Or: tag = "...", branch = "...", commit = "..."
-# # name = "custom-name"   # Optional display name
+    let contents = r#"# Plugins managed by pez.
+#
+# Use exactly one source per plugin: repo, url, or path.
+# Remote sources may use one selector: version, branch, tag, or commit.
 
 # [[plugins]]
-# url = "https://gitlab.com/owner/repo"  # Any Git host URL
+# repo = "owner/repo"        # GitHub shorthand
+# # version = "v3"          # Branch-or-tag selector
+# # name = "custom-name"    # Optional display name
+
+# [[plugins]]
+# repo = "gitlab.com/owner/repo"
 # # branch = "main"
 
 # [[plugins]]
-# path = "~/path/to/local/plugin"       # Local directory
+# url = "https://example.com/owner/repo.git"
+# # tag = "v1.2.3"
 
-# Add more plugins by copying the [[plugins]] block.
+# [[plugins]]
+# path = "~/plugins/local-plugin"
 "#;
     fs::write(&config_path, contents)?;
     info!("Created {}", config_path.display());


### PR DESCRIPTION
This pull request updates the project documentation to clarify that pez is a lockfile-backed plugin manager for fish, enhances the introductory materials for new users, and restructures the architecture documentation for improved readability and accuracy. The most important changes are summarized below.

**Project description and onboarding improvements:**

* The project description in both `Cargo.toml` and `README.md` is updated to emphasize that pez is a lockfile-backed plugin manager for fish, rather than just Rust-based. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L5-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R88)
* The `README.md` is rewritten for clarity, providing a more concise overview, clearer installation instructions, and a streamlined quick start section. It now highlights lockfile features, migration guidance, and security considerations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R88) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L119-L203)

**Documentation reorganization and enhancements:**

* The architecture documentation in `docs/architecture.md` is reorganized into thematic sections (module map, install/upgrade/uninstall flows, path and hook models), making it easier to understand the codebase structure and data flows.
* The `README.md` now links to a reorganized docs section, grouping guides for getting started, commands, configuration, install/build, migration, FAQ, and architecture for easier navigation.

**Security and migration guidance:**

* Security notes are updated to clarify that pez does not verify plugin signatures or sandbox code, and users are advised to trust and verify plugins, especially when migrating from other managers.
* Migration instructions from fisher are clarified, emphasizing a safe migration path and the importance of verification before removing the previous manager. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R88) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L119-L203)