### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pez"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pez"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 description = "A lockfile-backed plugin manager for fish."
 homepage = "https://github.com/tetzng/pez"


### PR DESCRIPTION
This pull request updates the version of the `pez` package in its manifest file to reflect a new release.

Version update:

* Bumped the version number in `Cargo.toml` from `0.4.2` to `0.5.0` to indicate a new release of the package.