### PR TITLE
chore: move schema generator to xtask

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           toolchain: ${{ matrix.rust }}
-      - run: cargo test --all-features
+      - run: cargo test --workspace --all-features
   formatting:
     name: cargo fmt
     runs-on: ubuntu-latest
@@ -46,7 +46,7 @@ jobs:
         with:
           components: clippy
       - name: clippy "No Default Features"
-        run: cargo clippy --workspace --no-default-features --all-targets
+        run: cargo clippy -p pez --no-default-features --all-targets
       - name: clippy "Default"
         run: cargo clippy --workspace --all-targets
       - name: clippy "All Features"
@@ -60,6 +60,6 @@ jobs:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       - name: regenerate schema
-        run: cargo run --features schema-gen --bin gen-config-schema
+        run: cargo run -p xtask -- gen-config-schema
       - name: check schema up to date
         run: git diff --exit-code -- config.schema.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,6 +1472,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "pez",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ license = "MIT"
 keywords = ["fish", "plugin", "manager"]
 categories = ["command-line-utilities"]
 
+[workspace]
+members = [".", "xtask"]
+resolver = "3"
+
 [dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
 console = "0.16.3"
@@ -38,11 +42,6 @@ libc = "0.2"
 
 [features]
 schema-gen = ["schemars"]
-
-[[bin]]
-name = "gen-config-schema"
-path = "src/bin/gen_config_schema.rs"
-required-features = ["schema-gen"]
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -175,7 +175,7 @@ fish and XDG variables also participate in path resolution:
 Regenerate it after config model changes:
 
 ```sh
-cargo run --features schema-gen --bin gen-config-schema
+cargo run -p xtask -- gen-config-schema
 ```
 
 Include the schema update in the same change as the model change.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+anyhow = "1.0.102"
+pez = { path = "..", features = ["schema-gen"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,11 +1,27 @@
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 fn main() -> anyhow::Result<()> {
-    let output_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config.schema.json");
+    let mut args = env::args().skip(1);
+    match args.next().as_deref() {
+        Some("gen-config-schema") => gen_config_schema(),
+        Some(command) => anyhow::bail!("unknown xtask command: {command}"),
+        None => anyhow::bail!("missing xtask command"),
+    }
+}
+
+fn gen_config_schema() -> anyhow::Result<()> {
+    let output_path = workspace_root().join("config.schema.json");
     pez::schema::write_config_schema(&output_path)?;
 
     println!("Wrote {}", output_path.display());
     Ok(())
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask manifest should be under workspace root")
+        .to_path_buf()
 }
 
 #[cfg(test)]
@@ -25,8 +41,8 @@ mod tests {
     }
 
     #[test]
-    fn main_overwrites_schema_file_with_generated_content() {
-        let output_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config.schema.json");
+    fn gen_config_schema_overwrites_schema_file_with_generated_content() {
+        let output_path = workspace_root().join("config.schema.json");
         let original = fs::read_to_string(&output_path).expect("read existing schema");
         let _guard = RestoreFile {
             path: output_path.clone(),
@@ -34,7 +50,7 @@ mod tests {
         };
 
         fs::write(&output_path, "not a schema").expect("seed schema content");
-        main().expect("run schema generator");
+        gen_config_schema().expect("run schema generator");
 
         let generated = fs::read_to_string(&output_path).expect("read generated schema");
         assert_ne!(generated, "not a schema");


### PR DESCRIPTION
This pull request restructures the configuration schema generation by introducing a new `xtask` workspace member, moving the schema generation logic into it, and updating the related workflow and documentation. The changes modernize the build setup, improve maintainability, and clarify the schema generation process.

**Workspace and Project Structure Updates:**

* Added a `[workspace]` section to `Cargo.toml`, declaring `xtask` as a workspace member and setting the resolver to version 3.
* Removed the old `[[bin]]` entry for `gen-config-schema` from `Cargo.toml`, as schema generation is now handled by `xtask`.
* Added a new `xtask` crate with its own `Cargo.toml`, depending on `pez` with the `schema-gen` feature.

**Schema Generation Refactor:**

* Moved the schema generation code from `src/bin/gen_config_schema.rs` to `xtask/src/main.rs`, refactoring it to support subcommands (e.g., `gen-config-schema`) and updating file path resolution to work from the workspace root. [[1]](diffhunk://#diff-9c5e61698d6d8a8ef4a3da7075c31857769134a932ac141d4eb62f68f131aa35L1-R26) [[2]](diffhunk://#diff-9c5e61698d6d8a8ef4a3da7075c31857769134a932ac141d4eb62f68f131aa35L28-R53)

**CI and Documentation Updates:**

* Updated the CI workflow to invoke schema generation via `cargo run -p xtask -- gen-config-schema` and adjusted test and clippy commands for improved correctness and clarity. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL24-R24) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL49-R49) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL63-R63)
* Updated documentation in `docs/configuration.md` to instruct users to use the new `xtask` command for schema generation.