### PR TITLE
fix: enable HTTPS support for libgit2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,9 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe",
  "openssl-sys",
+ "url",
 ]
 
 [[package]]
@@ -637,6 +639,12 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "3"
 [dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
 console = "0.16.3"
-git2 = { version = "0.21.0", features = [ "vendored-libgit2", "vendored-openssl" ] }
+git2 = { version = "0.21.0", features = [ "https", "vendored-libgit2", "vendored-openssl" ] }
 serde = "1.0.228"
 serde_derive = "1.0.216"
 sha2 = "0.11.0"

--- a/src/git.rs
+++ b/src/git.rs
@@ -379,6 +379,15 @@ mod tests {
     use std::path::Path;
     use tempfile::tempdir;
 
+    #[test]
+    fn libgit2_is_built_with_https_support() {
+        let version = git2::Version::get();
+        assert!(
+            version.https(),
+            "libgit2 must be built with HTTPS support: {version:?}"
+        );
+    }
+
     fn init_repo_with_commit(path: &Path) -> (git2::Repository, git2::Oid) {
         let repo = git2::Repository::init(path).unwrap();
         let mut cfg = repo.config().unwrap();


### PR DESCRIPTION
This pull request ensures that the `git2` library is built with HTTPS support and adds a test to verify this configuration. This is important for secure communication with remote repositories. The main changes are:

Dependency update:

* Added the `https` feature to the `git2` dependency in `Cargo.toml` to ensure libgit2 is built with HTTPS support.

Testing:

* Added a test in `src/git.rs` to assert that libgit2 is built with HTTPS support, helping to catch misconfigurations early in CI or local development.