### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pez"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pez"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "A lockfile-backed plugin manager for fish."
 homepage = "https://github.com/tetzng/pez"


### PR DESCRIPTION
This pull request makes a minor update to the `pez` package version in the `Cargo.toml` file, incrementing it from 0.5.0 to 0.5.1.